### PR TITLE
Fix strand parsing in module1

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -36,7 +36,10 @@ def parse_repeatmasker(input_path, output_path):
                 start = int(fields[1])
                 end = int(fields[2])
                 name = fields[3]
-                strand = fields[4]
+                if len(fields) >= 6:
+                    strand = fields[5]
+                else:
+                    strand = fields[4]
             else:
                 continue
             fout.write(f"{chrom}\t{start}\t{end}\t{name}\t.\t{strand}\n")


### PR DESCRIPTION
## Summary
- handle both 5- and 6-column BED files in `parse_repeatmasker`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fbd6ee3048322b86b102b985284ef