### PR TITLE
Fix README typos and subprocess checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ conda install haplongliner
 
 Clone the repository:
 ```bash
-git clone https://github.com/yourusername/HapLongLINEr.gitcd HapLongLINEr
+git clone https://github.com/yourusername/HapLongLINEr.git
+cd HapLongLINEr
 ```
 
 Install dependencies if necessary:
@@ -87,13 +88,12 @@ Output:
 
 ### Module 3: Sequence Repository
 
-Input:
-- BED file of L1 insertions (e.g., from Module 1 or 2) or L1 coordinate in chr:start-end format
-- Reference version: `--refv hs1` or `--refv hg38`
+Module 3 builds a sequence repository from previously identified insertions.
+Currently the only required argument is the output directory.
 
 Command:
 ```bash
-haplongliner db --in your.bed --refv hs1 --out output_folder
+haplongliner db --out output_folder
 ```
 
 Output:

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -96,14 +96,14 @@ def run_module1(input_fasta, repeatmasker_file, reference_fasta, outdir="module1
             f"seqtk subseq {input_fasta} - | "
             f"seqtk seq -U -l 0 -"
         )
-        subprocess.run(plus_cmd, shell=True, stdout=out_fa)
+        subprocess.run(plus_cmd, shell=True, stdout=out_fa, check=True)
         # Minus strand
         minus_cmd = (
             f"awk '$6==\"-\"' {fl_bed} | "
             f"seqtk subseq {input_fasta} - | "
             f"seqtk seq -U -r -l 0 -"
         )
-        subprocess.run(minus_cmd, shell=True, stdout=out_fa)
+        subprocess.run(minus_cmd, shell=True, stdout=out_fa, check=True)
 
     # 4. Extract flanking 2kb regions (upstream and downstream)
     fl_minus2kb_bed = outdir / "FL-2kb.bed"


### PR DESCRIPTION
## Summary
- split clone and cd commands in README
- update Module 3 instructions in README to reflect CLI
- ensure subprocess errors surface in module1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbd6eeb148322b259368118492eef