### PR TITLE
Fix output directory handling

### DIFF
--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -35,7 +35,7 @@ def main():
     ref_group.add_argument("-r", "--reference", choices=["hs1", "hg38"], help="Reference genome: 'hs1' or 'hg38' (remote)")
     ref_group.add_argument("-c", "--custom", help="Custom reference FASTA or gzipped FASTA (local path)")
 
-    parser_rm.add_argument("-o", "--out", dest="output", required=True, help="Output BED file")
+    parser_rm.add_argument("-o", "--out", dest="output", required=True, help="Output directory for intermediate files")
     parser_rm.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS,
                            help="Show this help message and exit.")
 

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -64,15 +64,14 @@ def download_if_needed(url, local_path):
     print(f"[INFO] Download complete: {local_path}")
     return str(local_path)
 
-def run_module1(input_fasta, repeatmasker_file, reference_fasta, output_bed="module1_output.bed"):
+def run_module1(input_fasta, repeatmasker_file, reference_fasta, output_dir="module1_output"):
     """
     RepeatMasker-based L1 discovery pipeline.
     Downloads remote reference if needed.
     Handles RepeatMasker BED, BED.gz, .out, or .out.gz input.
     """
-    output_bed = Path(output_bed)
-    outdir = output_bed.parent if output_bed.parent != Path("") else Path(".")
-    outdir.mkdir(exist_ok=True)
+    outdir = Path(output_dir)
+    outdir.mkdir(parents=True, exist_ok=True)
 
     # If reference_fasta is a URL, download it to the data folder
     if reference_fasta.startswith("http://") or reference_fasta.startswith("https://"):
@@ -86,7 +85,7 @@ def run_module1(input_fasta, repeatmasker_file, reference_fasta, output_bed="mod
         f"  Input: {input_fasta}\n"
         f"  RepeatMasker: {repeatmasker_file}\n"
         f"  Reference: {reference_fasta}\n"
-        f"  Output BED: {output_bed}\n"
+        f"  Output Dir: {outdir}\n"
     )
 
     # 1. Parse RepeatMasker file to unified BED6
@@ -188,6 +187,5 @@ def run_module1(input_fasta, repeatmasker_file, reference_fasta, output_bed="mod
         combined_out,
     )
 
-    # Final output BED-like table
-    shutil.copy(combined_out, output_bed)
-    print(f"Module 1 completed. Results in {output_bed}")
+    # Final output table
+    print(f"Module 1 completed. Results in {combined_out}")


### PR DESCRIPTION
## Summary
- change module1 to treat `-o/--out` as a directory
- update CLI help text accordingly

## Testing
- `pip install -e .`
- `haplongliner rm -h | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6840953e23208322bfc6b9ba28d61f44