### PR TITLE
Fix pyproject with build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a minimal `[build-system]` section using setuptools so `pip install .` works

## Testing
- `pip install .`

------
https://chatgpt.com/codex/tasks/task_e_6848a0c5d1c483229f7af314b65b1b23