### PR TITLE
Fix liftover key offsets

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -49,13 +49,13 @@ def combine_table(plus_file: str, minus_file: str, intact_file: str, fl_bed: str
             chrom, start, end, name, dot, strand = f[:6]
             start_i = int(start)
             end_i = int(end)
-            m = start_i - 1999
+            m = start_i - 2000
             p = end_i + 2000
-            px = end_i + 1
-            mx = start_i + 1
+            px = end_i
+            mx = start_i
             mkey = f"{chrom}:{m}-{start_i}"
             pkey = f"{chrom}:{px}-{p}"
-            ikey = f"{chrom}_{mx}_{end_i}"
+            ikey = f"{chrom}_{mx + 1}_{end_i}"
 
             m_val = minus.get(mkey, "").split("\t") if minus.get(mkey) else []
             p_val = plus.get(pkey, "").split("\t") if plus.get(pkey) else []

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -148,12 +148,12 @@ def run_module1(
     fl_plus2kb_bed = outdir / "FL+2kb.bed"
     # Upstream
     subprocess.run(
-        f"""awk 'BEGIN{{OFS="\\t"}} {{$2=$2-2000; $3=$2+2000; print $0}}' {fl_bed} > {fl_minus2kb_bed}""",
+        f"""awk 'BEGIN{{OFS=\"\t\"}} {{$3=$2; $2=$2-2000; print $0}}' {fl_bed} > {fl_minus2kb_bed}""",
         shell=True, check=True
     )
     # Downstream
     subprocess.run(
-        f"""awk 'BEGIN{{OFS="\\t"}} {{$3=$3+2000; print $0}}' {fl_bed} > {fl_plus2kb_bed}""",
+        f"""awk 'BEGIN{{OFS=\"\t\"}} {{$2=$3; $3=$3+2000; print $0}}' {fl_bed} > {fl_plus2kb_bed}""",
         shell=True, check=True
     )
 


### PR DESCRIPTION
## Summary
- fix computation of flanking regions in module1
- adjust liftover key generation for minimap outputs

## Testing
- `pip install -e .`
- `python3 -m compileall -q haplongliner`

------
https://chatgpt.com/codex/tasks/task_e_6848a3b024cc8322bf98f41cda8e2c7a