### PR TITLE
Fix parsing of scaffold identifiers with underscores

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -1,4 +1,5 @@
 import sys
+import re
 from typing import Dict
 
 
@@ -25,12 +26,12 @@ def _read_intact(file_path: str) -> Dict[str, str]:
             if not line.strip():
                 continue
             fields = line.strip().split()
-            parts = fields[0].split("_")
-            if len(parts) < 4:
+            m = re.match(r"^(.+?)_(\d+)_(\d+)_([+-])(?:_.*)?$", fields[0])
+            if not m:
                 continue
-            name = "_".join(parts[: len(parts) - 4 + 1])
-            g = f"{name}_{parts[-3]}_{parts[-2]}"
-            result[g] = line.strip()
+            chrom, start, end, _ = m.groups()
+            key = f"{chrom}_{start}_{end}"
+            result[key] = line.strip()
     return result
 
 

--- a/haplongliner/process_orf.py
+++ b/haplongliner/process_orf.py
@@ -19,11 +19,13 @@ def process_orf_fasta(in_fasta, out_bed):
                 continue
             start = int(fields[1].lstrip("["))
             end = int(fields[3].rstrip("]"))
-            parts = fields[0][1:].split("_")
-            if len(parts) < 4:
+
+            header = fields[0][1:]
+            m = re.match(r"^(.+?)_(\d+)_(\d+)_([+-])(?:_.*)?$", header)
+            if not m:
                 continue
-            l1_id = "_".join(parts[:3])
-            l1_strand = parts[3]
+            chrom, lstart, lend, l1_strand = m.groups()
+            l1_id = f"{chrom}_{lstart}_{lend}"
             strand = "+" if end >= start else "-"
             length = abs(end - start)
             fout.write(


### PR DESCRIPTION
## Summary
- handle underscores in scaffold names when parsing getorf results
- correctly parse intact ORF table keys even when chromosome names include `_`

## Testing
- `pytest -q`
- `python -m compileall -q haplongliner`

------
https://chatgpt.com/codex/tasks/task_e_6849d135b4708322a325b43cb5320165