### PR TITLE
Fix coordinate handling

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -56,7 +56,8 @@ def combine_table(plus_file: str, minus_file: str, intact_file: str, fl_bed: str
             mx = start_i
             mkey = f"{chrom}:{m}-{start_i}"
             pkey = f"{chrom}:{px}-{p}"
-            ikey = f"{chrom}_{mx + 1}_{end_i}"
+            # ORF coordinates are stored in 0-based space, so use them directly
+            ikey = f"{chrom}_{mx}_{end_i}"
 
             m_val = minus.get(mkey, "").split("\t") if minus.get(mkey) else []
             p_val = plus.get(pkey, "").split("\t") if plus.get(pkey) else []

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -14,7 +14,7 @@ from .combine_table import combine_table
 def parse_repeatmasker(input_path, output_path, log_path=None):
     """
     Parse RepeatMasker BED, BED.gz, .out, or .out.gz file and write a unified
-    BED-like file::
+    BED-like file using 0-based half-open coordinates::
 
         chrom  start  end  name  .  strand
 
@@ -44,7 +44,9 @@ def parse_repeatmasker(input_path, output_path, log_path=None):
             try:
                 if is_out:
                     chrom = fields[4]
-                    start = int(fields[5]) - 1  # .out is 1-based
+                    # RepeatMasker .out uses 1-based inclusive coordinates
+                    # Convert to 0-based half-open
+                    start = int(fields[5]) - 1
                     end = int(fields[6])
                     name = fields[9]
                     strand = fields[8]

--- a/haplongliner/process_orf.py
+++ b/haplongliner/process_orf.py
@@ -17,8 +17,14 @@ def process_orf_fasta(in_fasta, out_bed):
             fields = line.strip().split()
             if len(fields) < 4:
                 continue
-            start = int(fields[1].lstrip("["))
-            end = int(fields[3].rstrip("]"))
+            pos_start = int(fields[1].lstrip("["))
+            pos_end = int(fields[3].rstrip("]"))
+
+            # getorf reports coordinates as 1-based inclusive. Convert to
+            # 0-based half-open to match the rest of the pipeline.
+            start = min(pos_start, pos_end) - 1
+            end = max(pos_start, pos_end)
+            strand = "+" if pos_end >= pos_start else "-"
 
             header = fields[0][1:]
             m = re.match(r"^(.+?)_(\d+)_(\d+)_([+-])(?:_.*)?$", header)
@@ -26,8 +32,7 @@ def process_orf_fasta(in_fasta, out_bed):
                 continue
             chrom, lstart, lend, l1_strand = m.groups()
             l1_id = f"{chrom}_{lstart}_{lend}"
-            strand = "+" if end >= start else "-"
-            length = abs(end - start)
+            length = end - start
             fout.write(
                 f"{l1_id}\t{start}\t{end}\t{strand}\t{length}\t{l1_strand}\n"
             )


### PR DESCRIPTION
## Summary
- document 0-based output in `parse_repeatmasker`
- normalize ORF parsing to emit 0-based coordinates
- make `combine_table` expect 0-based ORF positions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849da0942e48322a39a45011510af71