### PR TITLE
Fix parsed_repeatmasker length column

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -16,7 +16,7 @@ def parse_repeatmasker(input_path, output_path, log_path=None):
     Parse RepeatMasker BED, BED.gz, .out, or .out.gz file and write a unified
     BED-like file using 0-based half-open coordinates::
 
-        chrom  start  end  name  .  strand
+        chrom  start  end  name  length  strand
 
     ``log_path`` optionally records skipped malformed lines.
     """
@@ -63,7 +63,10 @@ def parse_repeatmasker(input_path, output_path, log_path=None):
                 skipped.append(line.rstrip())
                 continue
 
-            fout.write(f"{chrom}\t{start}\t{end}\t{name}\t.\t{strand}\n")
+            length = end - start
+            fout.write(
+                f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\n"
+            )
 
     if log_path and skipped:
         with open(log_path, "w") as logf:


### PR DESCRIPTION
## Summary
- include L1 length when parsing RepeatMasker BED/.out files

## Testing
- `python - <<'PY'
from haplongliner.module1_RM import parse_repeatmasker
parse_repeatmasker('sample.bed', 'parsed.bed')
print(open('parsed.bed').read())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6849df697cb08322bc1d708a6fa2797f