### PR TITLE
Fix combine_table coordinate handling

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -50,13 +50,14 @@ def combine_table(plus_file: str, minus_file: str, intact_file: str, fl_bed: str
             chrom, start, end, name, dot, strand = f[:6]
             start_i = int(start)
             end_i = int(end)
-            m = start_i - 2000
+            # Convert to the coordinate system used by the legacy pipeline.
+            m = start_i - 1999
             p = end_i + 2000
-            px = end_i
-            mx = start_i
+            px = end_i + 1
+            mx = start_i + 1
             mkey = f"{chrom}:{m}-{start_i}"
             pkey = f"{chrom}:{px}-{p}"
-            # ORF coordinates are stored in 0-based space, so use them directly
+            # ORF headers store 1-based coordinates
             ikey = f"{chrom}_{mx}_{end_i}"
 
             m_val = minus.get(mkey, "").split("\t") if minus.get(mkey) else []

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -157,8 +157,9 @@ def run_module1(
     with open(fl_fa) as fin, open(fl_rename_fa, "w") as fout:
         for line in fin:
             if line.startswith(">"):
-                header = line.strip().replace(":", "_").replace("-", "_")
-                header = header.replace("(+)", "_+").replace("(-)", "_-")
+                # Preserve strand information before removing hyphens
+                header = line.strip().replace("(+)", "_+").replace("(-)", "_-")
+                header = header.replace(":", "_").replace("-", "_")
                 fout.write(header + "\n")
             else:
                 fout.write(line)


### PR DESCRIPTION
## Summary
- preserve strand indicators when sanitising FASTA headers
- adjust coordinate math in `combine_table`

## Testing
- `python -m py_compile haplongliner/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f276f3c883229d8f1e429f92cea2