### PR TITLE
Add git LFS check for blast database

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -10,6 +10,7 @@ from .process_orf import process_orf_fasta
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
 from .combine_table import combine_table
+from .utils import verify_blast_db
 
 def parse_repeatmasker(input_path, output_path, log_path=None):
     """
@@ -226,11 +227,13 @@ def run_module1(
     orf_bed = outdir / "FLAllORF.bed"
     process_orf_fasta(orf_fa, orf_bed)
     blastp_out = outdir / "FLAllORF.blastp"
+    db_prefix = Path("data") / "L1rpORF12p.fa"
+    verify_blast_db(db_prefix)
     subprocess.run(
         [
             "blastp",
             "-db",
-            str(Path("data") / "L1rpORF12p.fa"),
+            str(db_prefix),
             "-query",
             str(orf_fa),
             "-outfmt",

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -1,6 +1,6 @@
 import shutil
 import sys
-
+from pathlib import Path
 
 def check_dependencies():
     """Ensure required external tools are available."""
@@ -10,3 +10,21 @@ def check_dependencies():
         sys.exit(
             f"Error: The following required tools are missing from your PATH: {', '.join(missing)}"
         )
+
+
+def verify_blast_db(db_prefix):
+    """Ensure the BLAST database exists and is not a Git LFS placeholder."""
+    db_path = Path(db_prefix)
+    if not db_path.exists():
+        sys.exit(f"Error: BLAST database '{db_prefix}' not found.")
+
+    if db_path.stat().st_size < 200:
+        with open(db_path) as fh:
+            first_line = fh.readline()
+        if first_line.startswith("version https://git-lfs.github.com"):
+            sys.exit(
+                "Error: BLAST database appears to be a Git LFS placeholder. "
+                "Run 'git lfs pull' to download the required data files."
+            )
+
+


### PR DESCRIPTION
## Summary
- protect against running BLAST on missing data files
- add verify_blast_db helper and use in module1

## Testing
- `python -m haplongliner.cli -h` *(fails: The following required tools are missing from your PATH: seqtk, minimap2, getorf, blastp)*

------
https://chatgpt.com/codex/tasks/task_e_684a0daaedf88322b982731bb4aebeab