### PR TITLE
Add length cutoff options and update CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,31 @@ Input:
 
 Command:
 ```bash
-haplongliner rm --in your.genome.fa --mask repeatmasker.bed --reference hs1 --out output_dir
+haplongliner rm \
+  --in your.genome.fa \
+  --mask repeatmasker.bed \
+  --reference hs1 \
+  --out output_dir
 ```
+The minimum L1 length cutoff is 5 kb by default and can be adjusted with
+`-l/--length`.
 Or:
 ```bash
-haplongliner rm --in your.genome.fa --mask repeatmasker.bed --custom custom_reference.fa.gz --out output_dir
+haplongliner rm \
+  --in your.genome.fa \
+  --mask repeatmasker.bed \
+  --custom custom_reference.fa.gz \
+  --out output_dir
 ```
 To troubleshoot malformed RepeatMasker entries, use the optional
 `--log-skipped` parameter to record skipped lines:
 ```bash
-haplongliner rm --in your.genome.fa --mask repeatmasker.bed \
-  --reference hs1 --out output_dir --log-skipped skipped.log
+haplongliner rm \
+  --in your.genome.fa \
+  --mask repeatmasker.bed \
+  --reference hs1 \
+  --out output_dir \
+  --log-skipped skipped.log
 ```
 
 Output:
@@ -89,8 +103,13 @@ Input:
 
 Command:
 ```bash
-haplongliner sv --in your.genome.fa --sv your.sv.vcf --l1ref pangenome_L1_reference.fa --out output_file.bed
+haplongliner sv \
+  --in your.genome.fa \
+  --sv your.sv.vcf \
+  -1 pangenome_L1_reference.fa \
+  --out output_file.bed
 ```
+The `-l/--length` option can be used here as well to change the minimum L1 length.
 Output:
 - OUT.TXT file with L1 info from your assembly and corresponding refence genome (hs1/hg38) coordinates and ORF status
 - Log file (when using `-g/--log`) that summarizes results of each step of the pipeline module

--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -88,6 +88,15 @@ def main():
     parser_rm.add_argument("-m", "--mask", required=True, help="RepeatMasker BED or .out file")
 
     parser_rm.add_argument(
+        "-l",
+        "--length",
+        dest="length",
+        type=int,
+        default=5000,
+        help="Minimum L1 length (default: 5000)",
+    )
+
+    parser_rm.add_argument(
         "--log-skipped",
         dest="log_skipped",
         help="File to log malformed RepeatMasker lines",
@@ -119,7 +128,15 @@ def main():
     parser_sv._optionals.title = "Options"
     parser_sv.add_argument("-i", "--in", dest="input", required=True, help="Input haploid assembly FASTA")
     parser_sv.add_argument("-s", "--sv", required=True, help="Structural variant callset")
-    parser_sv.add_argument("-l", "--l1ref", required=True, help="Pangenome-level L1 reference FASTA")
+    parser_sv.add_argument("-1", dest="l1ref", required=True, help="Pangenome-level L1 reference FASTA")
+    parser_sv.add_argument(
+        "-l",
+        "--length",
+        dest="length",
+        type=int,
+        default=5000,
+        help="Minimum L1 length (default: 5000)",
+    )
     parser_sv.add_argument("-o", "--out", dest="output", required=True, help="Output BED file")
     parser_sv.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS,
                            help="Show this help message and exit.")
@@ -181,9 +198,16 @@ def main():
             reference,
             args.output,
             log_skipped=args.log_skipped,
+            min_length=args.length,
         )
     elif args.command == "sv":
-        run_module2(args.input, args.sv, args.l1ref, args.output)
+        run_module2(
+            args.input,
+            args.sv,
+            args.l1ref,
+            args.output,
+            min_length=args.length,
+        )
     elif args.command == "db":
         run_module3(args.output)
 

--- a/haplongliner/extract_l1.py
+++ b/haplongliner/extract_l1.py
@@ -1,5 +1,10 @@
-def extract_l1_from_bed(infile, outfile=None):
-    import sys
+"""Utility to extract full-length L1 records from a BED file."""
+
+import sys
+
+
+def extract_l1_from_bed(infile: str, outfile: str | None = None, min_length: int = 5000) -> None:
+    """Write BED records for L1s at least ``min_length`` bp long."""
     out = open(outfile, "w") if outfile else sys.stdout
     with open(infile) as f:
         for line in f:
@@ -11,15 +16,26 @@ def extract_l1_from_bed(infile, outfile=None):
             name = fields[3]
             start = int(fields[1])
             end = int(fields[2])
-            if name.startswith("L1") and (end - start) >= 5000:
+            if name.startswith("L1") and (end - start) >= min_length:
                 print(line, end="", file=out)
     if outfile:
         out.close()
 
+
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description="Extract full-length L1s (>=5000bp) from BED file.")
+
+    parser = argparse.ArgumentParser(
+        description="Extract full-length L1s from BED file."
+    )
     parser.add_argument("infile", help="Input BED file")
     parser.add_argument("-o", "--outfile", help="Output file (default: stdout)")
+    parser.add_argument(
+        "-l",
+        "--length",
+        type=int,
+        default=5000,
+        help="Minimum L1 length to keep (default: 5000)",
+    )
     args = parser.parse_args()
-    extract_l1_from_bed(args.infile, args.outfile)
+    extract_l1_from_bed(args.infile, args.outfile, args.length)

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -95,6 +95,7 @@ def run_module1(
     reference_fasta,
     output_dir="module1_output",
     log_skipped=None,
+    min_length: int = 5000,
 ):
     """
     RepeatMasker-based L1 discovery pipeline.
@@ -102,6 +103,7 @@ def run_module1(
     Handles RepeatMasker BED, BED.gz, .out, or .out.gz input.
     ``log_skipped`` specifies a file to log malformed RepeatMasker lines. If not
     provided, the ``HAPLOGLINER_LOG_SKIPPED`` environment variable is checked.
+    ``min_length`` controls the minimum L1 length to retain (default 5000 bp).
     """
     if log_skipped is None:
         log_skipped = os.getenv("HAPLOGLINER_LOG_SKIPPED")
@@ -129,10 +131,17 @@ def run_module1(
     parse_repeatmasker(repeatmasker_file, parsed_bed, log_skipped)
 
     print("[STEP 2] Extracting full-length L1s")
-    # 2. Extract full-length L1s (>=5000bp) from parsed BED
+    # 2. Extract full-length L1s from parsed BED
     fl_bed = outdir / "FL.bed"
     subprocess.run([
-        "python3", "-m", "haplongliner.extract_l1", parsed_bed, "-o", str(fl_bed)
+        "python3",
+        "-m",
+        "haplongliner.extract_l1",
+        parsed_bed,
+        "-o",
+        str(fl_bed),
+        "-l",
+        str(min_length),
     ], check=True)
 
     print("[STEP 3] Extracting full-length L1 sequences")

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -18,8 +18,14 @@ def _read_paf(path: Path) -> Dict[str, List[str]]:
     return hits
 
 
-def _liftover_l1s(minus_paf: Path, plus_paf: Path, ref_bed: Path) -> List[Tuple[str, int, int, str, int, str]]:
-    """Infer target assembly coordinates for each L1 listed in ``ref_bed``."""
+def _liftover_l1s(
+    minus_paf: Path,
+    plus_paf: Path,
+    ref_bed: Path,
+    min_length: int,
+) -> List[Tuple[str, int, int, str, int, str]]:
+    """Infer target assembly coordinates for each L1 listed in ``ref_bed`` and
+    filter by ``min_length``."""
     minus = _read_paf(minus_paf)
     plus = _read_paf(plus_paf)
 
@@ -46,7 +52,8 @@ def _liftover_l1s(minus_paf: Path, plus_paf: Path, ref_bed: Path) -> List[Tuple[
             if end_t < start_t:
                 start_t, end_t = end_t, start_t
             length = int(end) - int(start)
-            lifted.append((tname, start_t, end_t, name, length, orient))
+            if length >= min_length:
+                lifted.append((tname, start_t, end_t, name, length, orient))
     return lifted
 
 
@@ -151,9 +158,22 @@ def _parse_repeatmasker(out_file: Path) -> List[str]:
     return hits
 
 
-def run_module2(input_fasta: str, sv_file: str, l1ref_fasta: str, output_bed: str) -> None:
+def run_module2(
+    input_fasta: str,
+    sv_file: str,
+    l1ref_fasta: str,
+    output_bed: str,
+    min_length: int = 5000,
+) -> None:
+    """RepeatMasker-free L1 discovery using structural variants."""
+
     print(
-        f"Module 2 running with:\n  Input: {input_fasta}\n  SV: {sv_file}\n  L1 Reference: {l1ref_fasta}\n  Output: {output_bed}"
+        "Module 2 running with:\n"
+        f"  Input: {input_fasta}\n"
+        f"  SV: {sv_file}\n"
+        f"  L1 Reference: {l1ref_fasta}\n"
+        f"  Output: {output_bed}\n"
+        f"  Min Length: {min_length}"
     )
 
     out_path = Path(output_bed)
@@ -170,7 +190,7 @@ def run_module2(input_fasta: str, sv_file: str, l1ref_fasta: str, output_bed: st
     subprocess.run(f"minimap2 -x asm5 {input_fasta} {plus_fa} > {plus_paf}", shell=True, check=True)
 
     ref_bed = Path('data') / 'HPRC_L1_hs_v2_v2fl.bed'
-    lifted = _liftover_l1s(minus_paf, plus_paf, ref_bed)
+    lifted = _liftover_l1s(minus_paf, plus_paf, ref_bed, min_length)
 
     deletions, insertions = _parse_sv(Path(sv_file))
     status = _classify_deletions(lifted, deletions, outdir)


### PR DESCRIPTION
## Summary
- add adjustable length filter to L1 extraction script
- support `--length` option in modules 1 and 2
- rename Module 2 L1 reference flag to `-1`
- update CLI handling
- refresh README usage examples with backslashes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee29522808322aa97d16a5dc3235c