### PR TITLE
Fix CLI option names and add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Command:
 haplongliner rm \
   --in your.genome.fa \
   --mask repeatmasker.bed \
-  --reference hs1 \
+  --ref hs1 \
   --out output_dir
 ```
 The minimum L1 length cutoff is 5 kb by default and can be adjusted with
@@ -78,14 +78,14 @@ haplongliner rm \
   --out output_dir
 ```
 To troubleshoot malformed RepeatMasker entries, use the optional
-`--log-skipped` parameter to record skipped lines:
+`-g/--log` parameter to record skipped lines:
 ```bash
 haplongliner rm \
   --in your.genome.fa \
   --mask repeatmasker.bed \
-  --reference hs1 \
+  --ref hs1 \
   --out output_dir \
-  --log-skipped skipped.log
+  --log skipped.log
 ```
 
 Output:
@@ -107,6 +107,7 @@ haplongliner sv \
   --in your.genome.fa \
   --sv your.sv.vcf \
   --l1ref pangenome_L1_reference.fa \
+  --log sv_skipped.log \
   --out output_file.bed
 ```
 The `-l/--length` option can be used here as well to change the minimum L1 length.

--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -97,15 +97,17 @@ def main():
     )
 
     parser_rm.add_argument(
-        "--log-skipped",
-        dest="log_skipped",
+        "-g",
+        "--log",
+        dest="log",
         help="File to log malformed RepeatMasker lines",
     )
 
     ref_group = parser_rm.add_mutually_exclusive_group(required=True)
     ref_group.add_argument(
         "-r",
-        "--reference",
+        "--ref",
+        dest="ref",
         choices=["hs1", "hg38"],
         help="Reference genome: 'hs1' or 'hg38' (downloaded to data/ if missing)"
     )
@@ -128,7 +130,7 @@ def main():
     parser_sv._optionals.title = "Options"
     parser_sv.add_argument("-i", "--in", dest="input", required=True, help="Input haploid assembly FASTA")
     parser_sv.add_argument("-s", "--sv", required=True, help="Structural variant callset")
-    parser_sv.add_argument("-1", dest="l1ref", required=True, help="Pangenome-level L1 reference FASTA")
+    parser_sv.add_argument("-1", "--l1ref", dest="l1ref", required=True, help="Pangenome-level L1 reference FASTA")
     parser_sv.add_argument(
         "-l",
         "--length",
@@ -136,6 +138,12 @@ def main():
         type=int,
         default=5000,
         help="Minimum L1 length (default: 5000)",
+    )
+    parser_sv.add_argument(
+        "-g",
+        "--log",
+        dest="log",
+        help="File to log malformed SV lines",
     )
     parser_sv.add_argument("-o", "--out", dest="output", required=True, help="Output BED file")
     parser_sv.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS,
@@ -186,9 +194,9 @@ def main():
 
     if args.command == "rm":
         # Determine reference path/URL
-        if args.reference == "hs1":
+        if args.ref == "hs1":
             reference = HS1_URL
-        elif args.reference == "hg38":
+        elif args.ref == "hg38":
             reference = HG38_URL
         else:
             reference = args.custom
@@ -197,7 +205,7 @@ def main():
             args.mask,
             reference,
             args.output,
-            log_skipped=args.log_skipped,
+            log=args.log,
             min_length=args.length,
         )
     elif args.command == "sv":
@@ -206,6 +214,7 @@ def main():
             args.sv,
             args.l1ref,
             args.output,
+            log=args.log,
             min_length=args.length,
         )
     elif args.command == "db":

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -94,19 +94,19 @@ def run_module1(
     repeatmasker_file,
     reference_fasta,
     output_dir="module1_output",
-    log_skipped=None,
+    log=None,
     min_length: int = 5000,
 ):
     """
     RepeatMasker-based L1 discovery pipeline.
     Downloads remote reference if needed.
     Handles RepeatMasker BED, BED.gz, .out, or .out.gz input.
-    ``log_skipped`` specifies a file to log malformed RepeatMasker lines. If not
-    provided, the ``HAPLOGLINER_LOG_SKIPPED`` environment variable is checked.
+    ``log`` specifies a file to log malformed RepeatMasker lines. If not
+    provided, the ``HAPLOGLINER_LOG`` environment variable is checked.
     ``min_length`` controls the minimum L1 length to retain (default 5000 bp).
     """
-    if log_skipped is None:
-        log_skipped = os.getenv("HAPLOGLINER_LOG_SKIPPED")
+    if log is None:
+        log = os.getenv("HAPLOGLINER_LOG")
     outdir = Path(output_dir)
     outdir.mkdir(parents=True, exist_ok=True)
 
@@ -128,7 +128,7 @@ def run_module1(
     print("[STEP 1] Parsing RepeatMasker output")
     # 1. Parse RepeatMasker file to unified BED6
     parsed_bed = outdir / "parsed_repeatmasker.bed"
-    parse_repeatmasker(repeatmasker_file, parsed_bed, log_skipped)
+    parse_repeatmasker(repeatmasker_file, parsed_bed, log)
 
     print("[STEP 2] Extracting full-length L1s")
     # 2. Extract full-length L1s from parsed BED

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -63,38 +63,51 @@ def _write_bed(entries: List[Tuple[str, int, int, str, int, str]], path: Path) -
             out.write(f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\n")
 
 
-def _parse_sv(sv_path: Path) -> Tuple[List[Tuple[str, int, int]], List[Tuple[str, int, int]]]:
-    """Parse a simple VCF or BED SV file and return deletion and insertion regions."""
+def _parse_sv(
+    sv_path: Path, log_path: Path | None = None
+) -> Tuple[List[Tuple[str, int, int]], List[Tuple[str, int, int]]]:
+    """Parse a simple VCF or BED SV file and return deletion and insertion regions.
+    Unrecognized lines are written to ``log_path`` if provided."""
     deletions: List[Tuple[str, int, int]] = []
     insertions: List[Tuple[str, int, int]] = []
     is_vcf = sv_path.suffix.lower().endswith('vcf') or sv_path.suffix.lower() == '.gz'
+    skipped: List[str] = []
     with open(sv_path) as fh:
         for line in fh:
             if line.startswith('#') or not line.strip():
                 continue
             fields = line.rstrip().split('\t')
             if is_vcf or len(fields) > 5:
-                chrom = fields[0]
-                pos = int(fields[1]) - 1
-                info = fields[7] if len(fields) > 7 else ''
-                svtype = None
-                end = None
-                for item in info.split(';'):
-                    if item.startswith('SVTYPE='):
-                        svtype = item.split('=', 1)[1]
-                    elif item.startswith('END='):
-                        end = int(item.split('=', 1)[1]) - 1
-                if svtype == 'DEL' and end is not None:
-                    deletions.append((chrom, pos, end))
-                elif svtype == 'INS':
-                    insertions.append((chrom, pos, pos + 1))
+                try:
+                    chrom = fields[0]
+                    pos = int(fields[1]) - 1
+                    info = fields[7] if len(fields) > 7 else ''
+                    svtype = None
+                    end = None
+                    for item in info.split(';'):
+                        if item.startswith('SVTYPE='):
+                            svtype = item.split('=', 1)[1]
+                        elif item.startswith('END='):
+                            end = int(item.split('=', 1)[1]) - 1
+                    if svtype == 'DEL' and end is not None:
+                        deletions.append((chrom, pos, end))
+                    elif svtype == 'INS':
+                        insertions.append((chrom, pos, pos + 1))
+                except Exception:
+                    skipped.append(line.rstrip())
             else:
-                chrom, start, end = fields[:3]
-                svtype = fields[3].upper() if len(fields) > 3 else ''
-                if svtype == 'DEL':
-                    deletions.append((chrom, int(start), int(end)))
-                elif svtype == 'INS':
-                    insertions.append((chrom, int(start), int(end)))
+                try:
+                    chrom, start, end = fields[:3]
+                    svtype = fields[3].upper() if len(fields) > 3 else ''
+                    if svtype == 'DEL':
+                        deletions.append((chrom, int(start), int(end)))
+                    elif svtype == 'INS':
+                        insertions.append((chrom, int(start), int(end)))
+                except Exception:
+                    skipped.append(line.rstrip())
+    if log_path and skipped:
+        with open(log_path, 'w') as logf:
+            logf.write('\n'.join(skipped) + '\n')
     return deletions, insertions
 
 
@@ -163,9 +176,13 @@ def run_module2(
     sv_file: str,
     l1ref_fasta: str,
     output_bed: str,
+    log: str | None = None,
     min_length: int = 5000,
 ) -> None:
-    """RepeatMasker-free L1 discovery using structural variants."""
+    """RepeatMasker-free L1 discovery using structural variants.
+
+    ``log`` specifies a file to record malformed SV lines if provided.
+    """
 
     print(
         "Module 2 running with:\n"
@@ -192,7 +209,7 @@ def run_module2(
     ref_bed = Path('data') / 'HPRC_L1_hs_v2_v2fl.bed'
     lifted = _liftover_l1s(minus_paf, plus_paf, ref_bed, min_length)
 
-    deletions, insertions = _parse_sv(Path(sv_file))
+    deletions, insertions = _parse_sv(Path(sv_file), Path(log) if log else None)
     status = _classify_deletions(lifted, deletions, outdir)
 
     candidate_fa = outdir / 'candidates.fa'


### PR DESCRIPTION
## Summary
- add `--l1ref` long flag for Module 2
- rename Module 1 reference option to `--ref`
- rename `--log-skipped` to `-g/--log` and add same option to Module 2
- implement logging of malformed SV lines
- update README examples to use new options

## Testing
- `pytest -q`
- `python -m haplongliner.cli rm -h`
- `python -m haplongliner.cli sv -h`


------
https://chatgpt.com/codex/tasks/task_e_685ee61146d88322a98252c107fb7d48