### PR TITLE
Improve script output clarity and suppress tool logs

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -10,7 +10,7 @@ from .process_orf import process_orf_fasta
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
 from .combine_table import combine_table
-from .utils import verify_blast_db
+from .utils import verify_blast_db, run_quiet
 
 def parse_repeatmasker(input_path, output_path, log_path=None):
     """
@@ -125,6 +125,8 @@ def run_module1(
         f"  Output Dir: {outdir}\n"
     )
 
+    print()
+
     print("[STEP 1] Parsing RepeatMasker output")
     # 1. Parse RepeatMasker file to unified BED6
     parsed_bed = outdir / "parsed_repeatmasker.bed"
@@ -133,7 +135,7 @@ def run_module1(
     print("[STEP 2] Extracting full-length L1s")
     # 2. Extract full-length L1s from parsed BED
     fl_bed = outdir / "FL.bed"
-    subprocess.run([
+    run_quiet([
         "python3",
         "-m",
         "haplongliner.extract_l1",
@@ -155,7 +157,7 @@ def run_module1(
             f"seqtk seq -U -l 0 - | "
             "sed '/^>/ s/$/(+)/'"
         )
-        subprocess.run(plus_cmd, shell=True, stdout=out_fa, check=True)
+        run_quiet(plus_cmd, shell=True, stdout=out_fa, check=True)
         # Minus strand
         minus_cmd = (
             f"awk '$6==\"-\"' {fl_bed} | "
@@ -163,7 +165,7 @@ def run_module1(
             f"seqtk seq -U -r -l 0 - | "
             "sed '/^>/ s/$/(-)/'"
         )
-        subprocess.run(minus_cmd, shell=True, stdout=out_fa, check=True)
+        run_quiet(minus_cmd, shell=True, stdout=out_fa, check=True)
 
     # Sanitize FASTA headers for getorf compatibility
     fl_rename_fa = outdir / "FL.rename.fa"
@@ -189,12 +191,12 @@ def run_module1(
     fl_minus2kb_bed = outdir / "FL-2kb.bed"
     fl_plus2kb_bed = outdir / "FL+2kb.bed"
     # Upstream
-    subprocess.run(
+    run_quiet(
         f"""awk 'BEGIN{{OFS=\"\t\"}} {{$3=$2; $2=$2-2000; print $0}}' {fl_bed} > {fl_minus2kb_bed}""",
         shell=True, check=True
     )
     # Downstream
-    subprocess.run(
+    run_quiet(
         f"""awk 'BEGIN{{OFS=\"\t\"}} {{$2=$3; $3=$3+2000; print $0}}' {fl_bed} > {fl_plus2kb_bed}""",
         shell=True, check=True
     )
@@ -203,19 +205,19 @@ def run_module1(
     # 5. Extract sequences for flanking regions
     fl_minus2kb_fa = outdir / "FL-2kb.fa"
     fl_plus2kb_fa = outdir / "FL+2kb.fa"
-    subprocess.run(f"seqtk subseq {input_fasta} {fl_minus2kb_bed} | seqtk seq -U -l 0 - > {fl_minus2kb_fa}", shell=True, check=True)
-    subprocess.run(f"seqtk subseq {input_fasta} {fl_plus2kb_bed} | seqtk seq -U -l 0 - > {fl_plus2kb_fa}", shell=True, check=True)
+    run_quiet(f"seqtk subseq {input_fasta} {fl_minus2kb_bed} | seqtk seq -U -l 0 - > {fl_minus2kb_fa}", shell=True, check=True)
+    run_quiet(f"seqtk subseq {input_fasta} {fl_plus2kb_bed} | seqtk seq -U -l 0 - > {fl_plus2kb_fa}", shell=True, check=True)
 
     print("[STEP 6] Mapping flanks to reference genome")
     # 6. Map flanking regions to reference genome with minimap2 (using local FASTA)
     fl_minus2kb_minimap = outdir / "FL-2kb.minimap.txt"
     fl_plus2kb_minimap = outdir / "FL+2kb.minimap.txt"
-    subprocess.run(
+    run_quiet(
         f"minimap2 -x asm5 {reference_fasta} {fl_minus2kb_fa} > {fl_minus2kb_minimap}",
         shell=True,
         check=True,
     )
-    subprocess.run(
+    run_quiet(
         f"minimap2 -x asm5 {reference_fasta} {fl_plus2kb_fa} > {fl_plus2kb_minimap}",
         shell=True,
         check=True,
@@ -224,7 +226,7 @@ def run_module1(
     print("[STEP 7] Detecting ORFs")
     # 7. Detect ORFs and choose the longest ORF1/ORF2 per locus
     orf_fa = outdir / "FLAllORF.fa"
-    subprocess.run([
+    run_quiet([
         "getorf",
         "-sequence",
         fl_rename_fa,
@@ -238,7 +240,7 @@ def run_module1(
     blastp_out = outdir / "FLAllORF.blastp"
     db_prefix = Path("data") / "L1rpORF12p.fa"
     verify_blast_db(db_prefix)
-    subprocess.run(
+    run_quiet(
         [
             "blastp",
             "-db",

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -3,6 +3,8 @@ import subprocess
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from .utils import run_quiet
+
 
 def _read_paf(path: Path) -> Dict[str, List[str]]:
     """Return mapping ``query_name -> fields`` from a minimap2 PAF."""
@@ -113,7 +115,7 @@ def _parse_sv(
 
 def _bedtools_intersect(a: Path, b: Path, output: Path) -> None:
     with open(output, 'w') as out:
-        subprocess.run(['bedtools', 'intersect', '-wa', '-wb', '-a', str(a), '-b', str(b)], check=True, stdout=out)
+        run_quiet(['bedtools', 'intersect', '-wa', '-wb', '-a', str(a), '-b', str(b)], check=True, stdout=out)
 
 
 def _classify_deletions(lifted: List[Tuple[str, int, int, str, int, str]], deletions: List[Tuple[str, int, int]], outdir: Path) -> Dict[str, str]:
@@ -155,7 +157,7 @@ def _extract_sequences(fasta: Path, lifted: List[Tuple[str, int, int, str, int, 
                 bed.write(f"{chrom}\t{start}\t{end}\t{name}\n")
     if bed_path.stat().st_size > 0:
         cmd = f"seqtk subseq {fasta} {bed_path} | seqtk seq -U -l 0 - > {out_fa}"
-        subprocess.run(cmd, shell=True, check=True)
+        run_quiet(cmd, shell=True, check=True)
     else:
         out_fa.touch()
 
@@ -203,8 +205,8 @@ def run_module2(
     minus_paf = outdir / 'minus2kb.paf'
     plus_paf = outdir / 'plus2kb.paf'
 
-    subprocess.run(f"minimap2 -x asm5 {input_fasta} {minus_fa} > {minus_paf}", shell=True, check=True)
-    subprocess.run(f"minimap2 -x asm5 {input_fasta} {plus_fa} > {plus_paf}", shell=True, check=True)
+    run_quiet(f"minimap2 -x asm5 {input_fasta} {minus_fa} > {minus_paf}", shell=True, check=True)
+    run_quiet(f"minimap2 -x asm5 {input_fasta} {plus_fa} > {plus_paf}", shell=True, check=True)
 
     ref_bed = Path('data') / 'HPRC_L1_hs_v2_v2fl.bed'
     lifted = _liftover_l1s(minus_paf, plus_paf, ref_bed, min_length)
@@ -216,7 +218,7 @@ def run_module2(
     _extract_sequences(Path(input_fasta), lifted, status, candidate_fa)
 
     if candidate_fa.stat().st_size > 0:
-        subprocess.run(['RepeatMasker', str(candidate_fa)], check=True)
+        run_quiet(['RepeatMasker', str(candidate_fa)], check=True)
         rm_out = candidate_fa.with_suffix('.fa.out')
         l1_names = set(_parse_repeatmasker(rm_out))
     else:

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -28,3 +28,25 @@ def verify_blast_db(db_prefix):
             )
 
 
+def run_quiet(cmd, **kwargs):
+    """Run a subprocess suppressing output unless errors occur."""
+    import subprocess
+
+    kwargs.setdefault("stdout", subprocess.PIPE)
+    kwargs.setdefault("stderr", subprocess.PIPE)
+    result = subprocess.run(cmd, **kwargs)
+
+    def _to_str(stream):
+        if stream is None:
+            return ""
+        if isinstance(stream, bytes):
+            return stream.decode()
+        return str(stream)
+
+    if result.stderr:
+        sys.stderr.write(_to_str(result.stderr))
+    if result.returncode != 0:
+        if kwargs.get("stdout") == subprocess.PIPE and result.stdout:
+            sys.stderr.write(_to_str(result.stdout))
+        result.check_returncode()
+    return result


### PR DESCRIPTION
## Summary
- add `run_quiet` helper to hide subprocess output unless warnings/errors occur
- use `run_quiet` throughout modules
- add an extra blank line before `[STEP 1]`

## Testing
- `pytest -q`
- `python -m compileall haplongliner`

------
https://chatgpt.com/codex/tasks/task_e_685eea2c74ac8322898a1c37bed12bfd