### PR TITLE
Add input file validation

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -10,7 +10,12 @@ from .process_orf import process_orf_fasta
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
 from .combine_table import combine_table
-from .utils import verify_blast_db, run_quiet
+from .utils import (
+    verify_blast_db,
+    run_quiet,
+    verify_fasta_file,
+    verify_bed_file,
+)
 
 def parse_repeatmasker(input_path, output_path, log_path=None):
     """
@@ -109,6 +114,12 @@ def run_module1(
         log = os.getenv("HAPLOGLINER_LOG")
     outdir = Path(output_dir)
     outdir.mkdir(parents=True, exist_ok=True)
+
+    # Validate input files
+    verify_fasta_file(input_fasta)
+    verify_bed_file(repeatmasker_file)
+    if not reference_fasta.startswith("http://") and not reference_fasta.startswith("https://"):
+        verify_fasta_file(reference_fasta)
 
     # If reference_fasta is a URL, download it to the data folder
     if reference_fasta.startswith("http://") or reference_fasta.startswith("https://"):

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -3,7 +3,11 @@ import subprocess
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from .utils import run_quiet
+from .utils import (
+    run_quiet,
+    verify_fasta_file,
+    verify_sv_file,
+)
 
 
 def _read_paf(path: Path) -> Dict[str, List[str]]:
@@ -198,6 +202,11 @@ def run_module2(
     out_path = Path(output_bed)
     outdir = out_path.parent
     outdir.mkdir(parents=True, exist_ok=True)
+
+    # Validate input files
+    verify_fasta_file(input_fasta)
+    verify_sv_file(sv_file)
+    verify_fasta_file(l1ref_fasta)
 
     minus_fa = Path('data') / '-2kb.fa'
     plus_fa = Path('data') / '+2kb.fa'

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -50,3 +50,65 @@ def run_quiet(cmd, **kwargs):
             sys.stderr.write(_to_str(result.stdout))
         result.check_returncode()
     return result
+
+
+def verify_fasta_file(path: str) -> None:
+    """Exit if ``path`` is not a readable FASTA file."""
+    import gzip
+
+    fpath = Path(path)
+    if not fpath.exists():
+        sys.exit(f"Error: FASTA file '{path}' not found.")
+
+    opener = gzip.open if str(fpath).endswith(".gz") else open
+    try:
+        with opener(fpath, "rt") as fh:
+            first = fh.readline()
+        if not first.startswith(">"):
+            raise ValueError("Missing FASTA header")
+    except Exception as exc:
+        sys.exit(f"Error: FASTA file '{path}' appears malformed: {exc}")
+
+
+def _check_bed_line(line: str) -> None:
+    fields = line.rstrip().split()
+    if len(fields) < 3:
+        raise ValueError("fewer than 3 columns")
+    int(fields[1])
+    int(fields[2])
+
+
+def verify_bed_file(path: str) -> None:
+    """Exit if ``path`` is not a readable BED-like file."""
+    import gzip
+
+    bpath = Path(path)
+    if not bpath.exists():
+        sys.exit(f"Error: file '{path}' not found.")
+
+    opener = gzip.open if str(bpath).endswith(".gz") else open
+    try:
+        with opener(bpath, "rt") as fh:
+            for line in fh:
+                if line.startswith("#") or not line.strip():
+                    continue
+                _check_bed_line(line)
+                break
+            else:
+                raise ValueError("no data lines found")
+    except Exception as exc:
+        sys.exit(f"Error: BED file '{path}' appears malformed: {exc}")
+
+
+def verify_sv_file(path: str) -> None:
+    """Exit if ``path`` is not a readable SV/VCF/BED file."""
+    if not Path(path).exists():
+        sys.exit(f"Error: file '{path}' not found.")
+
+    with open(path) as fh:
+        for line in fh:
+            if line.startswith("#") or not line.strip():
+                continue
+            if len(line.rstrip().split("\t")) >= 3:
+                return
+        sys.exit(f"Error: SV file '{path}' appears malformed or empty.")


### PR DESCRIPTION
## Summary
- validate FASTA/BED/SV input files before processing
- enforce validation in module1 and module2 workflows

## Testing
- `python -m pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0692c9288322a84d51cbded94d5f