### PR TITLE
Fix gzipped SV parsing

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -78,8 +78,11 @@ def _parse_sv(
     deletions: List[Tuple[str, int, int]] = []
     insertions: List[Tuple[str, int, int]] = []
     is_vcf = sv_path.suffix.lower().endswith('vcf') or sv_path.suffix.lower() == '.gz'
+    import gzip
+
     skipped: List[str] = []
-    with open(sv_path) as fh:
+    opener = gzip.open if str(sv_path).endswith(".gz") else open
+    with opener(sv_path, "rt") as fh:
         for line in fh:
             if line.startswith('#') or not line.strip():
                 continue

--- a/tests/test_module2.py
+++ b/tests/test_module2.py
@@ -1,0 +1,22 @@
+import gzip
+from pathlib import Path
+
+from haplongliner.module2_SV import _parse_sv
+
+
+def test_parse_sv_handles_gz(tmp_path):
+    sv_gz = Path('tests/test.genome.HG00410.vcf.gz')
+    deletions, insertions = _parse_sv(sv_gz)
+    assert deletions[0] == ('chr1', 10828, 10858)
+    assert insertions[0] == ('chr1', 66365, 66366)
+    assert len(deletions) == 20629
+    assert len(insertions) == 23382
+
+    # also ensure plain VCF works
+    plain = tmp_path / 'test.vcf'
+    with gzip.open(sv_gz, 'rb') as src, open(plain, 'wb') as out:
+        out.write(src.read())
+    del2, ins2 = _parse_sv(plain)
+    assert del2 == deletions
+    assert ins2 == insertions
+


### PR DESCRIPTION
## Summary
- support reading gzipped VCF files in module2
- test gzipped SV parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f1d5a73708322ac864099487f6aee