### PR TITLE
Align module2 minimap parsing with module1

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -15,16 +15,34 @@ from .find_intact_orf import find_intact_orf
 
 
 def _read_paf(path: Path) -> Dict[str, List[str]]:
-    """Return mapping ``query_name -> fields`` from a minimap2 PAF."""
+    """Return mapping ``query_name -> fields`` from a minimap2 PAF.
+
+    Alignments shorter than 200 bp are ignored and, if multiple alignments are
+    present for a query, the longest one is retained.  This mirrors the handling
+    of minimap output performed in :func:`haplongliner.combine_table._read_minimap`.
+    """
+
     hits: Dict[str, List[str]] = {}
+    lengths: Dict[str, int] = {}
     with open(path) as fh:
         for line in fh:
             if not line.strip():
                 continue
             fields = line.rstrip().split('\t')
+            if len(fields) < 4:
+                continue
             qname = fields[0]
-            if qname not in hits:
+            try:
+                aln_len = int(fields[3]) - int(fields[2])
+            except ValueError:
+                continue
+            if aln_len < 200:
+                continue
+            prev_len = lengths.get(qname, -1)
+            if aln_len > prev_len:
                 hits[qname] = fields
+                lengths[qname] = aln_len
+
     return hits
 
 

--- a/tests/test_liftover.py
+++ b/tests/test_liftover.py
@@ -1,10 +1,63 @@
 from pathlib import Path
 
-from haplongliner.module2_SV import _liftover_l1s
+from haplongliner.module2_SV import _liftover_l1s, _read_paf
 
 
 def write_paf(path: Path, lines: list[str]) -> None:
     path.write_text("\n".join(lines) + "\n")
+
+
+def test_read_paf_filters_and_selects_longest(tmp_path):
+    paf = tmp_path / "test.paf"
+    lines = [
+        "\t".join([
+            "q1",
+            "1000",
+            "0",
+            "180",
+            "+",
+            "chr1",
+            "10000",
+            "0",
+            "180",
+            "180",
+            "180",
+            "60",
+        ]),
+        "\t".join([
+            "q1",
+            "1000",
+            "0",
+            "400",
+            "+",
+            "chr1",
+            "10000",
+            "200",
+            "600",
+            "400",
+            "400",
+            "60",
+        ]),
+        "\t".join([
+            "q2",
+            "1000",
+            "0",
+            "150",
+            "+",
+            "chr1",
+            "10000",
+            "0",
+            "150",
+            "150",
+            "150",
+            "60",
+        ]),
+    ]
+    write_paf(paf, lines)
+    hits = _read_paf(paf)
+    assert "q1" in hits
+    assert hits["q1"][3] == "400"
+    assert "q2" not in hits
 
 
 def test_liftover_l1s_plus_and_minus(tmp_path):


### PR DESCRIPTION
## Summary
- ensure `_read_paf` filters short minimap alignments and prefers the longest hit
- test the new behaviour

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815348c9748322b6902da7b14bfd9b