### PR TITLE
Rename module1 flanking outputs to PAF and share parser

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -1,22 +1,13 @@
 import sys
 import re
-from typing import Dict
+from typing import Dict, List
+
+from .utils import read_paf
 
 
-def _read_minimap(file_path: str) -> Dict[str, str]:
-    result = {}
-    with open(file_path) as fh:
-        for line in fh:
-            if not line.strip():
-                continue
-            fields = line.strip().split()
-            if len(fields) < 4:
-                continue
-            key = fields[0]
-            aln_len = int(fields[3]) - int(fields[2])
-            if aln_len >= 200 and (key not in result or "_" in result[key]):
-                result[key] = line.strip()
-    return result
+def _read_minimap(file_path: str) -> Dict[str, List[str]]:
+    """Wrapper around :func:`haplongliner.utils.read_paf`."""
+    return read_paf(file_path)
 
 
 def _read_intact(file_path: str) -> Dict[str, str]:
@@ -60,8 +51,8 @@ def combine_table(plus_file: str, minus_file: str, intact_file: str, fl_bed: str
             # ORF headers store 1-based coordinates
             ikey = f"{chrom}_{mx}_{end_i}"
 
-            m_val = minus.get(mkey, "").split("\t") if minus.get(mkey) else []
-            p_val = plus.get(pkey, "").split("\t") if plus.get(pkey) else []
+            m_val = minus.get(mkey, [])
+            p_val = plus.get(pkey, [])
 
             status = "present"
             if ikey in intact:

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -221,15 +221,15 @@ def run_module1(
 
     print("\n[STEP 6] Mapping flanks to reference genome")
     # 6. Map flanking regions to reference genome with minimap2 (using local FASTA)
-    fl_minus2kb_minimap = outdir / "FL-2kb.minimap.txt"
-    fl_plus2kb_minimap = outdir / "FL+2kb.minimap.txt"
+    fl_minus2kb_paf = outdir / "FL-2kb.paf"
+    fl_plus2kb_paf = outdir / "FL+2kb.paf"
     run_quiet(
-        f"minimap2 -x asm5 {reference_fasta} {fl_minus2kb_fa} > {fl_minus2kb_minimap}",
+        f"minimap2 -x asm5 {reference_fasta} {fl_minus2kb_fa} > {fl_minus2kb_paf}",
         shell=True,
         check=True,
     )
     run_quiet(
-        f"minimap2 -x asm5 {reference_fasta} {fl_plus2kb_fa} > {fl_plus2kb_minimap}",
+        f"minimap2 -x asm5 {reference_fasta} {fl_plus2kb_fa} > {fl_plus2kb_paf}",
         shell=True,
         check=True,
     )
@@ -277,8 +277,8 @@ def run_module1(
     # 9. Integrate ORF status and liftover information
     combined_out = outdir / "HapLongLINErRM.txt"
     combine_table(
-        fl_plus2kb_minimap,
-        fl_minus2kb_minimap,
+        fl_plus2kb_paf,
+        fl_minus2kb_paf,
         intact_out,
         fl_bed,
         combined_out,

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -8,42 +8,15 @@ from .utils import (
     verify_sv_file,
     verify_bed_file,
     verify_blast_db,
+    read_paf,
 )
 from .module1_RM import download_if_needed
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
 
 
-def _read_paf(path: Path) -> Dict[str, List[str]]:
-    """Return mapping ``query_name -> fields`` from a minimap2 PAF.
-
-    Alignments shorter than 200 bp are ignored and, if multiple alignments are
-    present for a query, the longest one is retained.  This mirrors the handling
-    of minimap output performed in :func:`haplongliner.combine_table._read_minimap`.
-    """
-
-    hits: Dict[str, List[str]] = {}
-    lengths: Dict[str, int] = {}
-    with open(path) as fh:
-        for line in fh:
-            if not line.strip():
-                continue
-            fields = line.rstrip().split('\t')
-            if len(fields) < 4:
-                continue
-            qname = fields[0]
-            try:
-                aln_len = int(fields[3]) - int(fields[2])
-            except ValueError:
-                continue
-            if aln_len < 200:
-                continue
-            prev_len = lengths.get(qname, -1)
-            if aln_len > prev_len:
-                hits[qname] = fields
-                lengths[qname] = aln_len
-
-    return hits
+# use shared PAF parser from utils for backward compatibility
+_read_paf = read_paf
 
 
 def _load_master_coords(paths: Iterable[Path]) -> Dict[str, Tuple[str, int, int, str]]:

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -1,6 +1,7 @@
 import shutil
 import sys
 from pathlib import Path
+from typing import Dict, List
 
 def check_dependencies():
     """Ensure required external tools are available."""
@@ -116,6 +117,37 @@ def verify_sv_file(path: str) -> None:
             if len(line.rstrip().split("\t")) >= 3:
                 return
         sys.exit(f"Error: SV file '{path}' appears malformed or empty.")
+
+
+def read_paf(path: str | Path) -> Dict[str, List[str]]:
+    """Return mapping ``query_name -> fields`` from a minimap2 PAF.
+
+    Alignments shorter than 200 bp are ignored and, if multiple alignments are
+    present for a query, the longest one is retained.
+    """
+
+    hits: Dict[str, List[str]] = {}
+    lengths: Dict[str, int] = {}
+    with open(path) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            fields = line.rstrip().split('\t')
+            if len(fields) < 4:
+                continue
+            qname = fields[0]
+            try:
+                aln_len = int(fields[3]) - int(fields[2])
+            except ValueError:
+                continue
+            if aln_len < 200:
+                continue
+            prev_len = lengths.get(qname, -1)
+            if aln_len > prev_len:
+                hits[qname] = fields
+                lengths[qname] = aln_len
+
+    return hits
 
 
 def verify_repeatmasker_file(path: str) -> None:


### PR DESCRIPTION
## Summary
- rename intermediate flank alignment outputs to `FL±2kb.paf`
- move PAF parsing logic into `utils.read_paf`
- reuse shared parser in module2 and combine_table

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688156537dd88322bf4ee071d6298fa0