### PR TITLE
Fix FASTA renaming for 5-column BED files

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -102,10 +102,13 @@ def _rename_fa_with_bed(fa_path: Path, bed_path: Path) -> None:
         for line in bed:
             if not line.strip() or line.startswith("#"):
                 continue
-            f = line.strip().split()
-            if len(f) < 6:
+            fields = line.strip().split()
+            if len(fields) < 5:
                 continue
-            chrom, start, end, *_rest, strand = f[:6]
+            if len(fields) == 5:
+                chrom, start, end, _name, strand = fields
+            else:
+                chrom, start, end, *_rest, strand = fields[:6]
             records.append((chrom, int(start) + 1, int(end), strand))
 
     tmp = fa_path.with_suffix(".tmp")


### PR DESCRIPTION
## Summary
- improve `_rename_fa_with_bed` to parse 5-column BED files
- enable use of provided HPRC BED files without errors

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688292a7ca6483228222a3d3cf6d578f