### PR TITLE
Rename module output and temp files

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -17,6 +17,7 @@ from .utils import (
     verify_repeatmasker_file,
 )
 
+
 def parse_repeatmasker(input_path, output_path, log_path=None):
     """
     Parse RepeatMasker BED, BED.gz, .out, or .out.gz file and write a unified
@@ -70,14 +71,13 @@ def parse_repeatmasker(input_path, output_path, log_path=None):
                 continue
 
             length = end - start
-            fout.write(
-                f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\n"
-            )
+            fout.write(f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\n")
 
     if log_path and skipped:
         with open(log_path, "w") as logf:
             logf.write("\n".join(skipped) + "\n")
     print(f"Skipped {len(skipped)} malformed lines")
+
 
 def download_if_needed(url, local_path):
     """
@@ -89,7 +89,7 @@ def download_if_needed(url, local_path):
         return str(local_path)
     print(f"[INFO] Downloading reference genome from {url} ...")
     local_path.parent.mkdir(parents=True, exist_ok=True)
-    with urllib.request.urlopen(url) as response, open(local_path, 'wb') as out_file:
+    with urllib.request.urlopen(url) as response, open(local_path, "wb") as out_file:
         shutil.copyfileobj(response, out_file)
     print(f"[INFO] Download complete: {local_path}")
     return str(local_path)
@@ -123,6 +123,7 @@ def _rename_fa_with_bed(fa_path: Path, bed_path: Path) -> None:
                 out.write(line)
     os.replace(tmp, fa_path)
 
+
 def run_module1(
     input_fasta,
     repeatmasker_file,
@@ -147,7 +148,9 @@ def run_module1(
     # Validate input files
     verify_fasta_file(input_fasta)
     verify_repeatmasker_file(repeatmasker_file)
-    if not reference_fasta.startswith("http://") and not reference_fasta.startswith("https://"):
+    if not reference_fasta.startswith("http://") and not reference_fasta.startswith(
+        "https://"
+    ):
         verify_fasta_file(reference_fasta)
 
     # If reference_fasta is a URL, download it to the data folder
@@ -174,25 +177,28 @@ def run_module1(
 
     print("\n[STEP 2] Extracting full-length L1s")
     # 2. Extract full-length L1s from parsed BED
-    fl_bed = outdir / "FL.bed"
-    run_quiet([
-        "python3",
-        "-m",
-        "haplongliner.extract_l1",
-        parsed_bed,
-        "-o",
-        str(fl_bed),
-        "-l",
-        str(min_length),
-    ], check=True)
+    candidate_bed = outdir / "candidate.bed"
+    run_quiet(
+        [
+            "python3",
+            "-m",
+            "haplongliner.extract_l1",
+            parsed_bed,
+            "-o",
+            str(candidate_bed),
+            "-l",
+            str(min_length),
+        ],
+        check=True,
+    )
 
     print("\n[STEP 3] Extracting full-length L1 sequences")
     # 3. Extract the sequence of the full-length L1s (plus and minus strand)
-    fl_fa = outdir / "FL.fa"
-    with open(fl_fa, "w") as out_fa:
+    candidate_fa = outdir / "candidate.fa"
+    with open(candidate_fa, "w") as out_fa:
         # Plus strand
         plus_cmd = (
-            f"awk '$6==\"+\"' {fl_bed} | "
+            f"awk '$6==\"+\"' {candidate_bed} | "
             f"seqtk subseq {input_fasta} - | "
             f"seqtk seq -U -l 0 - | "
             "sed -e '/^>/ s/:/;/' -e '/^>/ s/-/;/' -e '/^>/ s/$/;+/'"
@@ -200,76 +206,80 @@ def run_module1(
         run_quiet(plus_cmd, shell=True, stdout=out_fa, check=True)
         # Minus strand
         minus_cmd = (
-            f"awk '$6==\"-\"' {fl_bed} | "
+            f"awk '$6==\"-\"' {candidate_bed} | "
             f"seqtk subseq {input_fasta} - | "
             f"seqtk seq -U -r -l 0 - | "
             "sed -e '/^>/ s/:/;/' -e '/^>/ s/-/;/' -e '/^>/ s/$/;-/'"
         )
         run_quiet(minus_cmd, shell=True, stdout=out_fa, check=True)
 
-        
     print("\n[STEP 4] Extracting 2kb flanking regions")
     # 4. Extract flanking 2kb regions (upstream and downstream)
-    fl_minus2kb_bed = outdir / "FL-2kb.bed"
-    fl_plus2kb_bed = outdir / "FL+2kb.bed"
+    candidate_minus2kb_bed = outdir / "candidate_minus2kb.bed"
+    candidate_plus2kb_bed = outdir / "candidate_plus2kb.bed"
     # Upstream
     run_quiet(
-        f"""awk 'BEGIN{{OFS=\"\t\"}} {{$3=$2; $2=$2-2000; print $0}}' {fl_bed} > {fl_minus2kb_bed}""",
-        shell=True, check=True
+        f"""awk 'BEGIN{{OFS=\"\t\"}} {{$3=$2; $2=$2-2000; print $0}}' {candidate_bed} > {candidate_minus2kb_bed}""",
+        shell=True,
+        check=True,
     )
     # Downstream
     run_quiet(
-        f"""awk 'BEGIN{{OFS=\"\t\"}} {{$2=$3; $3=$3+2000; print $0}}' {fl_bed} > {fl_plus2kb_bed}""",
-        shell=True, check=True
+        f"""awk 'BEGIN{{OFS=\"\t\"}} {{$2=$3; $3=$3+2000; print $0}}' {candidate_bed} > {candidate_plus2kb_bed}""",
+        shell=True,
+        check=True,
     )
 
     print("\n[STEP 5] Getting sequences for flanking regions")
     # 5. Extract sequences for flanking regions
-    fl_minus2kb_fa = outdir / "FL-2kb.fa"
-    fl_plus2kb_fa = outdir / "FL+2kb.fa"
+    candidate_minus2kb_fa = outdir / "candidate_minus2kb.fa"
+    candidate_plus2kb_fa = outdir / "candidate_plus2kb.fa"
     run_quiet(
-        f"seqtk subseq {input_fasta} {fl_minus2kb_bed} | seqtk seq -U -l 0 - > {fl_minus2kb_fa}",
+        f"seqtk subseq {input_fasta} {candidate_minus2kb_bed} | seqtk seq -U -l 0 - > {candidate_minus2kb_fa}",
         shell=True,
         check=True,
     )
-    _rename_fa_with_bed(fl_minus2kb_fa, fl_minus2kb_bed)
+    _rename_fa_with_bed(candidate_minus2kb_fa, candidate_minus2kb_bed)
     run_quiet(
-        f"seqtk subseq {input_fasta} {fl_plus2kb_bed} | seqtk seq -U -l 0 - > {fl_plus2kb_fa}",
+        f"seqtk subseq {input_fasta} {candidate_plus2kb_bed} | seqtk seq -U -l 0 - > {candidate_plus2kb_fa}",
         shell=True,
         check=True,
     )
-    _rename_fa_with_bed(fl_plus2kb_fa, fl_plus2kb_bed)
+    _rename_fa_with_bed(candidate_plus2kb_fa, candidate_plus2kb_bed)
 
     print("\n[STEP 6] Mapping flanks to reference genome")
     # 6. Map flanking regions to reference genome with minimap2 (using local FASTA)
-    fl_minus2kb_paf = outdir / "FL-2kb.paf"
-    fl_plus2kb_paf = outdir / "FL+2kb.paf"
+    candidate_minus2kb_paf = outdir / "candidate_minus2kb.paf"
+    candidate_plus2kb_paf = outdir / "candidate_plus2kb.paf"
     run_quiet(
-        f"minimap2 -x asm5 {reference_fasta} {fl_minus2kb_fa} > {fl_minus2kb_paf}",
+        f"minimap2 -x asm5 {reference_fasta} {candidate_minus2kb_fa} > {candidate_minus2kb_paf}",
         shell=True,
         check=True,
     )
     run_quiet(
-        f"minimap2 -x asm5 {reference_fasta} {fl_plus2kb_fa} > {fl_plus2kb_paf}",
+        f"minimap2 -x asm5 {reference_fasta} {candidate_plus2kb_fa} > {candidate_plus2kb_paf}",
         shell=True,
         check=True,
     )
 
     print("\n[STEP 7] Detecting ORFs")
     # 7. Detect ORFs and choose the longest ORF1/ORF2 per locus
-    orf_fa = outdir / "FLAllORF.fa"
-    run_quiet([
-        "getorf",
-        "-sequence",
-        str(fl_fa),
-        "-find",
-        "1",
-        "-outseq",
-        str(orf_fa),
-    ], check=True)
-    orf_bed = outdir / "FLAllORF.bed"
+    orf_fa = outdir / "candidate_orf.fa"
+    run_quiet(
+        [
+            "getorf",
+            "-sequence",
+            str(candidate_fa),
+            "-find",
+            "1",
+            "-outseq",
+            str(orf_fa),
+        ],
+        check=True,
+    )
+    orf_bed = outdir / "candidate_orf.bed"
     process_orf_fasta(orf_fa, orf_bed)
-    blastp_out = outdir / "FLAllORF.blastp"
+    blastp_out = outdir / "candidate_orf.blastp"
     db_prefix = Path("data") / "L1rpORF12p.fa"
     verify_blast_db(db_prefix)
     run_quiet(
@@ -286,22 +296,22 @@ def run_module1(
         ],
         check=True,
     )
-    longest_orf_out = outdir / "FLAllORF.combine.blastp"
+    longest_orf_out = outdir / "candidate_orf.combine.blastp"
     find_longest_orf(blastp_out, longest_orf_out)
 
     print("\n[STEP 8] Identifying intact ORFs")
     # 8. Identify intact ORFs
-    intact_out = outdir / "FLAllORF.intact.blastp"
+    intact_out = outdir / "candidate_orf.intact.blastp"
     find_intact_orf(longest_orf_out, intact_out)
 
     print("\n[STEP 9] Integrating ORF status and liftover info")
     # 9. Integrate ORF status and liftover information
-    combined_out = outdir / "HapLongLINErRM.txt"
+    combined_out = outdir / "haplongliner_rm.bed"
     combine_table(
-        fl_plus2kb_paf,
-        fl_minus2kb_paf,
+        candidate_plus2kb_paf,
+        candidate_minus2kb_paf,
         intact_out,
-        fl_bed,
+        candidate_bed,
         combined_out,
         min_length=min_length,
     )
@@ -322,4 +332,3 @@ def run_module1(
     #         os.remove(tmp)
     #     except FileNotFoundError:
     #         pass
-

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -110,8 +110,18 @@ def _write_bed(
     entries: List[Tuple[str, int, int, str, int, str, str, str, int, int]],
     path: Path,
 ) -> None:
-    with open(path, 'w') as out:
-        for chrom, start, end, name, length, strand, plus_info, minus_info, *_ in entries:
+    with open(path, "w") as out:
+        for (
+            chrom,
+            start,
+            end,
+            name,
+            length,
+            strand,
+            plus_info,
+            minus_info,
+            *_,
+        ) in entries:
             out.write(
                 f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\t{plus_info}\t{minus_info}\n"
             )
@@ -126,56 +136,60 @@ def _parse_sv(
     lines are written to ``log_path`` if provided."""
     deletions: List[Tuple[str, int, int]] = []
     insertions: List[Tuple[str, int, int, str]] = []
-    is_vcf = sv_path.suffix.lower().endswith('vcf') or sv_path.suffix.lower() == '.gz'
+    is_vcf = sv_path.suffix.lower().endswith("vcf") or sv_path.suffix.lower() == ".gz"
     import gzip
 
     skipped: List[str] = []
     opener = gzip.open if str(sv_path).endswith(".gz") else open
     with opener(sv_path, "rt") as fh:
         for line in fh:
-            if line.startswith('#') or not line.strip():
+            if line.startswith("#") or not line.strip():
                 continue
-            fields = line.rstrip().split('\t')
+            fields = line.rstrip().split("\t")
             if is_vcf or len(fields) > 5:
                 try:
                     chrom = fields[0]
                     pos = int(fields[1]) - 1
-                    info = fields[7] if len(fields) > 7 else ''
+                    info = fields[7] if len(fields) > 7 else ""
                     svtype = None
                     end = None
-                    for item in info.split(';'):
-                        if item.startswith('SVTYPE='):
-                            svtype = item.split('=', 1)[1]
-                        elif item.startswith('END='):
-                            end = int(item.split('=', 1)[1]) - 1
-                    if svtype == 'DEL' and end is not None:
+                    for item in info.split(";"):
+                        if item.startswith("SVTYPE="):
+                            svtype = item.split("=", 1)[1]
+                        elif item.startswith("END="):
+                            end = int(item.split("=", 1)[1]) - 1
+                    if svtype == "DEL" and end is not None:
                         deletions.append((chrom, pos, end))
-                    elif svtype == 'INS':
+                    elif svtype == "INS":
                         alt = fields[4]
-                        seq = '' if alt.startswith('<') else alt
+                        seq = "" if alt.startswith("<") else alt
                         insertions.append((chrom, pos, pos + 1, seq))
                 except Exception:
                     skipped.append(line.rstrip())
             else:
                 try:
                     chrom, start, end = fields[:3]
-                    svtype = fields[3].upper() if len(fields) > 3 else ''
-                    if svtype == 'DEL':
+                    svtype = fields[3].upper() if len(fields) > 3 else ""
+                    if svtype == "DEL":
                         deletions.append((chrom, int(start), int(end)))
-                    elif svtype == 'INS':
-                        seq = fields[4] if len(fields) > 4 else ''
+                    elif svtype == "INS":
+                        seq = fields[4] if len(fields) > 4 else ""
                         insertions.append((chrom, int(start), int(end), seq))
                 except Exception:
                     skipped.append(line.rstrip())
     if log_path and skipped:
-        with open(log_path, 'w') as logf:
-            logf.write('\n'.join(skipped) + '\n')
+        with open(log_path, "w") as logf:
+            logf.write("\n".join(skipped) + "\n")
     return deletions, insertions
 
 
 def _bedtools_intersect(a: Path, b: Path, output: Path) -> None:
-    with open(output, 'w') as out:
-        run_quiet(['bedtools', 'intersect', '-wa', '-wb', '-a', str(a), '-b', str(b)], check=True, stdout=out)
+    with open(output, "w") as out:
+        run_quiet(
+            ["bedtools", "intersect", "-wa", "-wb", "-a", str(a), "-b", str(b)],
+            check=True,
+            stdout=out,
+        )
 
 
 def _classify_sv(
@@ -207,7 +221,9 @@ def _classify_sv(
     _bedtools_intersect(lift_bed, del_bed, inter_del)
     _bedtools_intersect(lift_bed, ins_bed, inter_ins)
 
-    status: Dict[str, str] = {name: "present" for _, _, _, name, _, _, _, _, _, _ in lifted}
+    status: Dict[str, str] = {
+        name: "present" for _, _, _, name, _, _, _, _, _, _ in lifted
+    }
     ins_seqs: Dict[str, str] = {}
     with open(inter_del) as fh:
         for line in fh:
@@ -252,29 +268,29 @@ def _extract_sequences(
 ) -> None:
     """Extract candidate L1 sequences from the target assembly."""
 
-    bed_path = out_fa.with_suffix('.bed')
-    with open(bed_path, 'w') as bed:
+    bed_path = out_fa.with_suffix(".bed")
+    with open(bed_path, "w") as bed:
         for _, _, _, name, _, _, plus_info, _, t_start, t_end in lifted:
-            scaf, _ps, _pe, t_strand = plus_info.split(';')
+            scaf, _ps, _pe, t_strand = plus_info.split(";")
             bed.write(f"{scaf}\t{t_start}\t{t_end}\t{name}\t0\t{t_strand}\n")
 
     run_quiet(
         [
-            'bedtools',
-            'getfasta',
-            '-fi',
+            "bedtools",
+            "getfasta",
+            "-fi",
             str(fasta),
-            '-bed',
+            "-bed",
             str(bed_path),
-            '-name',
-            '-fo',
+            "-name",
+            "-fo",
             str(out_fa),
-            '-s',
+            "-s",
         ],
         check=True,
     )
 
-    with open(out_fa, 'a') as out:
+    with open(out_fa, "a") as out:
         for name, seq in ins_seqs.items():
             if len(seq) >= min_length:
                 out.write(f">{name}_ins\n{seq}\n")
@@ -287,12 +303,12 @@ def _parse_repeatmasker(out_file: Path, l1_len: int, cov_thresh: float) -> Set[s
     coverage: Dict[str, int] = {}
     with open(out_file) as fh:
         for line in fh:
-            if line.startswith(' '):
+            if line.startswith(" "):
                 parts = line.split()
-                if len(parts) >= 14 and re.search(r'L1', parts[9]):
+                if len(parts) >= 14 and re.search(r"L1", parts[9]):
                     name = parts[4]
-                    rep_start = int(parts[11].strip('()'))
-                    rep_end = int(parts[12].strip('()'))
+                    rep_start = int(parts[11].strip("()"))
+                    rep_end = int(parts[12].strip("()"))
                     cov = abs(rep_end - rep_start) + 1
                     coverage[name] = coverage.get(name, 0) + cov
     return {n for n, c in coverage.items() if c / l1_len >= cov_thresh}
@@ -305,36 +321,42 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
     if candidate_fa.stat().st_size == 0:
         return present, intact
 
-    orf_fa = candidate_fa.with_suffix('.orf.fa')
-    run_quiet([
-        'getorf',
-        '-sequence',
-        str(candidate_fa),
-        '-find',
-        '1',
-        '-outseq',
-        str(orf_fa),
-    ], check=True)
+    orf_fa = candidate_fa.with_suffix(".orf.fa")
+    run_quiet(
+        [
+            "getorf",
+            "-sequence",
+            str(candidate_fa),
+            "-find",
+            "1",
+            "-outseq",
+            str(orf_fa),
+        ],
+        check=True,
+    )
 
-    blastp_out = candidate_fa.with_suffix('.blastp')
-    db_prefix = Path('data') / 'L1rpORF12p.fa'
+    blastp_out = candidate_fa.with_suffix(".blastp")
+    db_prefix = Path("data") / "L1rpORF12p.fa"
     verify_blast_db(db_prefix)
-    run_quiet([
-        'blastp',
-        '-db',
-        str(db_prefix),
-        '-query',
-        str(orf_fa),
-        '-outfmt',
-        '6 std qlen slen sacc',
-        '-out',
-        str(blastp_out),
-    ], check=True)
+    run_quiet(
+        [
+            "blastp",
+            "-db",
+            str(db_prefix),
+            "-query",
+            str(orf_fa),
+            "-outfmt",
+            "6 std qlen slen sacc",
+            "-out",
+            str(blastp_out),
+        ],
+        check=True,
+    )
 
-    combined = candidate_fa.with_suffix('.combine.blastp')
+    combined = candidate_fa.with_suffix(".combine.blastp")
     find_longest_orf(blastp_out, combined)
 
-    intact_file = candidate_fa.with_suffix('.intact.blastp')
+    intact_file = candidate_fa.with_suffix(".intact.blastp")
     find_intact_orf(combined, intact_file)
 
     with open(combined) as fh:
@@ -344,7 +366,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             fields = line.strip().split()
             if len(fields) < 30:
                 continue
-            name = re.sub(r'_[0-9]+$', '', fields[0])
+            name = re.sub(r"_[0-9]+$", "", fields[0])
             try:
                 cov1 = int(fields[3]) / int(fields[13])
                 cov2 = int(fields[18]) / int(fields[28])
@@ -360,7 +382,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             fields = line.strip().split()
             if len(fields) < 30:
                 continue
-            name = re.sub(r'_[0-9]+$', '', fields[0])
+            name = re.sub(r"_[0-9]+$", "", fields[0])
             intact.add(name)
 
     return present, intact
@@ -372,19 +394,22 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
     if candidate_fa.stat().st_size == 0:
         return present
 
-    blastn_out = candidate_fa.with_suffix('.blastn')
-    ref_fa = Path('data') / 'L1rp.fa'
-    run_quiet([
-        'blastn',
-        '-query',
-        str(candidate_fa),
-        '-subject',
-        str(ref_fa),
-        '-outfmt',
-        '6 qacc length slen',
-        '-out',
-        str(blastn_out),
-    ], check=True)
+    blastn_out = candidate_fa.with_suffix(".blastn")
+    ref_fa = Path("data") / "L1rp.fa"
+    run_quiet(
+        [
+            "blastn",
+            "-query",
+            str(candidate_fa),
+            "-subject",
+            str(ref_fa),
+            "-outfmt",
+            "6 qacc length slen",
+            "-out",
+            str(blastn_out),
+        ],
+        check=True,
+    )
 
     longest: Dict[str, int] = {}
     with open(blastn_out) as fh:
@@ -394,7 +419,7 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
             f = line.strip().split()
             if len(f) < 3:
                 continue
-            name = re.sub(r'_[0-9]+$', '', f[0])
+            name = re.sub(r"_[0-9]+$", "", f[0])
             length = int(f[1])
             prev = longest.get(name, 0)
             if length > prev:
@@ -466,8 +491,8 @@ def run_module2(
             shell=True,
             check=True,
         )
-        minus_fa = outdir / "-2kb.fa"
-        plus_fa = outdir / "+2kb.fa"
+        minus_fa = outdir / "ref_minus2kb.fa"
+        plus_fa = outdir / "ref_plus2kb.fa"
         run_quiet(
             f"seqtk subseq {ref_path} {minus_bed} | seqtk seq -U -l 0 - > {minus_fa}",
             shell=True,
@@ -486,8 +511,8 @@ def run_module2(
             raise ValueError("Unsupported L1 reference")
         minus_fa_src = Path("data") / "-2kb.fa"
         plus_fa_src = Path("data") / "+2kb.fa"
-        minus_fa = outdir / "-2kb.fa"
-        plus_fa = outdir / "+2kb.fa"
+        minus_fa = outdir / "ref_minus2kb.fa"
+        plus_fa = outdir / "ref_plus2kb.fa"
         shutil.copyfile(minus_fa_src, minus_fa)
         shutil.copyfile(plus_fa_src, plus_fa)
         ref_bed = Path("data") / "HPRC_L1_hs1_v2_v2fl.bed"
@@ -505,11 +530,13 @@ def run_module2(
         )
         _rename_fa_with_bed(minus_fa, minus_bed)
         _rename_fa_with_bed(plus_fa, plus_bed)
+        minus_bed.unlink(missing_ok=True)
+        plus_bed.unlink(missing_ok=True)
 
     print("\n[STEP 2] Mapping L1 flanks to input assembly")
 
-    minus_paf = outdir / "minus2kb.paf"
-    plus_paf = outdir / "plus2kb.paf"
+    minus_paf = outdir / "ref_minus2kb.paf"
+    plus_paf = outdir / "ref_plus2kb.paf"
 
     run_quiet(
         f"minimap2 -x asm5 {input_fasta} {minus_fa} > {minus_paf}",
@@ -535,16 +562,29 @@ def run_module2(
     status, ins_seqs = _classify_sv(lifted, deletions, insertions, outdir)
 
     candidate_fa = outdir / "candidates.fa"
-    _extract_sequences(Path(input_fasta), lifted, status, ins_seqs, candidate_fa, min_length)
+    _extract_sequences(
+        Path(input_fasta), lifted, status, ins_seqs, candidate_fa, min_length
+    )
 
     intact_names = _validate_orfs(candidate_fa)[1]
     presence_names = _validate_presence(candidate_fa, min_length)
 
     print("\n[STEP 6] Writing output table")
 
-    out_table = outdir / "HapLongLINErSV.txt"
+    out_table = outdir / "haplongliner_sv.bed"
     with open(out_table, "w") as out:
-        for chrom, start, end, name, length, strand, plus_info, minus_info, t_start, t_end in lifted:
+        for (
+            chrom,
+            start,
+            end,
+            name,
+            length,
+            strand,
+            plus_info,
+            minus_info,
+            t_start,
+            t_end,
+        ) in lifted:
             base_stat = status.get(name, "present")
             scaf, *_rest, t_strand = plus_info.split(";")
             target_len = t_end - t_start


### PR DESCRIPTION
## Summary
- standardize file naming for module1 and module2
- drop `FL` prefix in module1 outputs and use `candidate` names
- rename `AllORF` intermediate files to `_orf`
- rename reference flank files to `ref_plus2kb/fa` and `ref_minus2kb.fa`
- remove temporary HPRC flank BEDs
- update final output file names for both modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688298a925f0832287a5e39e1a368b1f