### PR TITLE
Honor BED strand in liftover_paf

### DIFF
--- a/scripts/liftover_paf.py
+++ b/scripts/liftover_paf.py
@@ -17,7 +17,7 @@ from typing import Dict, Iterable, List, Tuple
 # interval utilities (port of Interval.* helpers in paftools.js)
 # ---------------------------------------------------------------------------
 
-Interval = List[List[int]]
+Interval = List[List]
 
 
 def interval_sort(a: Interval) -> None:
@@ -101,12 +101,13 @@ def read_bed(path: str | None, to_merge: bool) -> Dict[str, Interval]:
             if len(fields) < 3:
                 continue
             chrom, start, end = fields[:3]
+            strand = fields[5] if len(fields) > 5 else "+"
             try:
                 s = int(start)
                 e = int(end)
             except ValueError:
                 continue
-            bed.setdefault(chrom, []).append([s, e])
+            bed.setdefault(chrom, []).append([s, e, strand])
     for chrom in list(bed.keys()):
         interval_sort(bed[chrom])
         if to_merge:
@@ -221,7 +222,7 @@ def liftover_paf(
                     r[idx][0] = coord
                 else:
                     r[idx][1] = coord + 1
-            for i, (s, e, *_) in enumerate(regs):
+            for i, (s, e, b_strand, *_) in enumerate(regs):
                 name = f"{t[0]}_{s}_{e}"
                 start = r[i][0]
                 end = r[i][1]
@@ -231,7 +232,8 @@ def liftover_paf(
                 if end < 0:
                     name += "_t3"
                     end = t[8]
-                print("\t".join([t[5], str(start), str(end), name, "0", strand]))
+                out_strand = t[4] if b_strand == "+" else ("+" if t[4] == "-" else "-")
+                print("\t".join([t[5], str(start), str(end), name, "0", out_strand]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_liftover_paf_strand.py
+++ b/tests/test_liftover_paf_strand.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import importlib.util
+import sys
+import pathlib
+
+spec = importlib.util.spec_from_file_location(
+    "liftover_paf",
+    pathlib.Path(__file__).resolve().parents[1] / "scripts" / "liftover_paf.py",
+)
+liftover_paf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(liftover_paf)
+
+def test_liftover_respects_strand(tmp_path, capsys):
+    paf = tmp_path / "test.paf"
+    bed = tmp_path / "test.bed"
+    paf.write_text("q1\t1000\t100\t200\t+\tchr1\t2000\t1000\t1100\t100\t100\t60\ttp:A:P\tcg:Z:100M\n")
+    bed.write_text("q1\t110\t130\tname1\t0\t+\nq1\t140\t150\tname2\t0\t-\n")
+    liftover_paf.liftover_paf(str(paf), str(bed), 0, 0, 2.0, False)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[0].endswith("\t+")
+    assert out[1].endswith("\t-")


### PR DESCRIPTION
## Summary
- support reading strand column in `liftover_paf.py`
- compute output strand based on BED and PAF orientation
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e8ff4d088322bc3b87a05eb76105