### PR TITLE
Update liftover_paf output fields

### DIFF
--- a/scripts/liftover_paf.py
+++ b/scripts/liftover_paf.py
@@ -101,13 +101,15 @@ def read_bed(path: str | None, to_merge: bool) -> Dict[str, Interval]:
             if len(fields) < 3:
                 continue
             chrom, start, end = fields[:3]
+            name = fields[3] if len(fields) > 3 else ""
+            score = fields[4] if len(fields) > 4 else "0"
             strand = fields[5] if len(fields) > 5 else "+"
             try:
                 s = int(start)
                 e = int(end)
             except ValueError:
                 continue
-            bed.setdefault(chrom, []).append([s, e, strand])
+            bed.setdefault(chrom, []).append([s, e, strand, name, score])
     for chrom in list(bed.keys()):
         interval_sort(bed[chrom])
         if to_merge:
@@ -222,8 +224,8 @@ def liftover_paf(
                     r[idx][0] = coord
                 else:
                     r[idx][1] = coord + 1
-            for i, (s, e, b_strand, *_) in enumerate(regs):
-                name = f"{t[0]}_{s}_{e}"
+            for i, (s, e, b_strand, b_name, b_score, *_) in enumerate(regs):
+                name = f"{t[0]};{s};{e};{b_strand};{b_name}"
                 start = r[i][0]
                 end = r[i][1]
                 if start < 0:
@@ -233,7 +235,7 @@ def liftover_paf(
                     name += "_t3"
                     end = t[8]
                 out_strand = t[4] if b_strand == "+" else ("+" if t[4] == "-" else "-")
-                print("\t".join([t[5], str(start), str(end), name, "0", out_strand]))
+                print("\t".join([t[5], str(start), str(end), name, str(b_score), out_strand]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_liftover_paf_strand.py
+++ b/tests/test_liftover_paf_strand.py
@@ -17,5 +17,11 @@ def test_liftover_respects_strand(tmp_path, capsys):
     bed.write_text("q1\t110\t130\tname1\t0\t+\nq1\t140\t150\tname2\t0\t-\n")
     liftover_paf.liftover_paf(str(paf), str(bed), 0, 0, 2.0, False)
     out = capsys.readouterr().out.strip().splitlines()
-    assert out[0].endswith("\t+")
-    assert out[1].endswith("\t-")
+    f1 = out[0].split("\t")
+    f2 = out[1].split("\t")
+    assert f1[3] == "q1;110;130;+;name1"
+    assert f2[3] == "q1;140;150;-;name2"
+    assert f1[4] == "0"
+    assert f2[4] == "0"
+    assert f1[5] == "+"
+    assert f2[5] == "-"


### PR DESCRIPTION
## Summary
- support BED name and score in `liftover_paf`
- check new output columns in unit test

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f05ffd888322b14a78e31522cab2