### PR TITLE
Fix ORF name parsing with semicolons

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -17,7 +17,7 @@ def _read_intact(file_path: str) -> Dict[str, str]:
             if not line.strip():
                 continue
             fields = line.strip().split()
-            m = re.match(r"^(.+?)[;_](\d+)[;_](\d+)[;_]([+-])(?:_.*)?$", fields[0])
+            m = re.match(r"^(.+?)[;_](\d+)[;_](\d+)[;_]([+-])(?:[;_].*)?$", fields[0])
             if not m:
                 continue
             chrom, start, end, _ = m.groups()

--- a/haplongliner/find_longest_orf.py
+++ b/haplongliner/find_longest_orf.py
@@ -17,7 +17,7 @@ def find_longest_orf(blastp_file, out_file):
             if not line.strip():
                 continue
             F = line.strip().split()
-            name = re.sub(r"_[0-9]+$", "", F[0])
+            name = re.sub(r"[;_][0-9]+$", "", F[0])
             subject = F[1]
             aln_len = int(F[3])
             if aln_len >= len_dict.get(name, {}).get(subject, 0):

--- a/haplongliner/process_orf.py
+++ b/haplongliner/process_orf.py
@@ -27,7 +27,7 @@ def process_orf_fasta(in_fasta, out_bed):
             strand = "+" if pos_end >= pos_start else "-"
 
             header = fields[0][1:]
-            m = re.match(r"^(.+?)[;_](\d+)[;_](\d+)[;_]([+-])(?:_.*)?$", header)
+            m = re.match(r"^(.+?)[;_](\d+)[;_](\d+)[;_]([+-])(?:[;_].*)?$", header)
             if not m:
                 continue
             chrom, lstart, lend, l1_strand = m.groups()


### PR DESCRIPTION
## Summary
- allow semicolon-delimited ORF headers to be parsed
- update regexes in `process_orf_fasta` and `combine_table`
- strip semicolon ORF indices when selecting longest ORFs

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f5e4822083228f77004791840e99