### PR TITLE
Switch minimap2 preset to asm10

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -263,12 +263,12 @@ def run_module1(
     candidate_minus2kb_paf = outdir / "candidate_minus2kb.paf"
     candidate_plus2kb_paf = outdir / "candidate_plus2kb.paf"
     run_quiet(
-        f"minimap2 -x asm5 {reference_fasta} {candidate_minus2kb_fa} > {candidate_minus2kb_paf}",
+        f"minimap2 -x asm10 {reference_fasta} {candidate_minus2kb_fa} > {candidate_minus2kb_paf}",
         shell=True,
         check=True,
     )
     run_quiet(
-        f"minimap2 -x asm5 {reference_fasta} {candidate_plus2kb_fa} > {candidate_plus2kb_paf}",
+        f"minimap2 -x asm10 {reference_fasta} {candidate_plus2kb_fa} > {candidate_plus2kb_paf}",
         shell=True,
         check=True,
     )

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -539,12 +539,12 @@ def run_module2(
     plus_paf = outdir / "ref_plus2kb.paf"
 
     run_quiet(
-        f"minimap2 -x asm5 {input_fasta} {minus_fa} > {minus_paf}",
+        f"minimap2 -x asm10 {input_fasta} {minus_fa} > {minus_paf}",
         shell=True,
         check=True,
     )
     run_quiet(
-        f"minimap2 -x asm5 {input_fasta} {plus_fa} > {plus_paf}",
+        f"minimap2 -x asm10 {input_fasta} {plus_fa} > {plus_paf}",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
## Summary
- use the asm10 preset instead of asm5 when mapping sequences with minimap2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f87eee7483228f604a45f2ad56ac