### PR TITLE
Fix module2 candidate sequence names

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -291,21 +291,22 @@ def _extract_sequences(
             scaf, _ps, _pe, t_strand = plus_info.split(";")
             bed.write(f"{scaf}\t{t_start}\t{t_end}\t{name}\t0\t{t_strand}\n")
 
-    run_quiet(
-        [
-            "bedtools",
-            "getfasta",
-            "-fi",
-            str(fasta),
-            "-bed",
-            str(bed_path),
-            "-name",
-            "-fo",
-            str(out_fa),
-            "-s",
-        ],
-        check=True,
-    )
+    with open(out_fa, "w") as out:
+        plus_cmd = (
+            f"awk '$6==\"+\"' {bed_path} | "
+            f"seqtk subseq {fasta} - | "
+            f"seqtk seq -U -l 0 - | "
+            "sed -e '/^>/ s/:/;/' -e '/^>/ s/-/;/' -e '/^>/ s/$/;+/'"
+        )
+        run_quiet(plus_cmd, shell=True, stdout=out, check=True)
+
+        minus_cmd = (
+            f"awk '$6==\"-\"' {bed_path} | "
+            f"seqtk subseq {fasta} - | "
+            f"seqtk seq -U -r -l 0 - | "
+            "sed -e '/^>/ s/:/;/' -e '/^>/ s/-/;/' -e '/^>/ s/$/;-/'"
+        )
+        run_quiet(minus_cmd, shell=True, stdout=out, check=True)
 
     with open(out_fa, "a") as out:
         for name, seq in ins_seqs.items():

--- a/tests/test_module2_extract.py
+++ b/tests/test_module2_extract.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from haplongliner.module2_SV import _extract_sequences
+
+def test_extract_sequences_names(tmp_path):
+    fa = tmp_path / "test.fa"
+    fa.write_text(">chr1\n" + "A" * 100 + "\n")
+    lifted = [
+        ("chr1", 10, 20, "L1a", 10, "+", "chr1;10;20;+", "chr1;10;20;+", 10, 20),
+        ("chr1", 30, 40, "L1b", 10, "-", "chr1;30;40;-", "chr1;30;40;-", 30, 40),
+    ]
+    status = {"L1a": "present", "L1b": "present"}
+    out = tmp_path / "out.fa"
+    _extract_sequences(fa, lifted, status, {}, out, 5)
+    headers = [l.strip() for l in open(out) if l.startswith(">")]
+    assert headers == [">chr1;11;20;+", ">chr1;31;40;-"]


### PR DESCRIPTION
## Summary
- fix candidate FASTA naming in module2 by using `seqtk` like module1
- add regression test for header naming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688493d7e38c8322b5aaa1fd354f982d