### PR TITLE
Adjust seqtk header coords

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -49,13 +49,13 @@ def combine_table(
             start_i = int(start)
             end_i = int(end)
             # Convert to the coordinate system used by the legacy pipeline.
-            m = start_i - 1999
+            m = start_i - 2000
             p = end_i + 2000
-            px = end_i + 1
-            mx = start_i + 1
+            px = end_i
+            mx = start_i
             mkey = f"{chrom};{m};{start_i};{strand}"
             pkey = f"{chrom};{px};{p};{strand}"
-            # ORF headers store 1-based coordinates
+            # ORF headers now store 0-based coordinates
             ikey = f"{chrom}_{mx}_{end_i}"
 
             m_val = minus.get(mkey, [])

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -15,6 +15,7 @@ from .utils import (
     run_quiet,
     verify_fasta_file,
     verify_repeatmasker_file,
+    shift_fasta_start,
 )
 
 
@@ -109,7 +110,7 @@ def _rename_fa_with_bed(fa_path: Path, bed_path: Path) -> None:
                 chrom, start, end, _name, strand = fields
             else:
                 chrom, start, end, *_rest, strand = fields[:6]
-            records.append((chrom, int(start) + 1, int(end), strand))
+            records.append((chrom, int(start), int(end), strand))
 
     tmp = fa_path.with_suffix(".tmp")
     with open(fa_path) as fin, open(tmp, "w") as out:
@@ -226,6 +227,8 @@ def run_module1(
             "sed -e '/^>/ s/:/;/' -e '/^>/ s/-/;/' -e '/^>/ s/$/;-/'"
         )
         run_quiet(minus_cmd, shell=True, stdout=out_fa, check=True)
+
+    shift_fasta_start(candidate_fa)
 
     print("\n[STEP 4] Extracting 2kb flanking regions")
     # 4. Extract flanking 2kb regions (upstream and downstream)

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -8,6 +8,7 @@ from .utils import (
     verify_sv_file,
     verify_bed_file,
     verify_blast_db,
+    shift_fasta_start,
     read_paf,
 )
 from .module1_RM import download_if_needed
@@ -307,6 +308,8 @@ def _extract_sequences(
             "sed -e '/^>/ s/:/;/' -e '/^>/ s/-/;/' -e '/^>/ s/$/;-/'"
         )
         run_quiet(minus_cmd, shell=True, stdout=out, check=True)
+
+    shift_fasta_start(out_fa)
 
     with open(out_fa, "a") as out:
         for name, seq in ins_seqs.items():

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -1,5 +1,6 @@
 import shutil
 import sys
+import os
 from pathlib import Path
 from typing import Dict, List
 
@@ -51,6 +52,27 @@ def run_quiet(cmd, **kwargs):
             sys.stderr.write(_to_str(result.stdout))
         result.check_returncode()
     return result
+
+
+def shift_fasta_start(fa_path: Path, delta: int = -1) -> None:
+    """Adjust start coordinate in FASTA headers by ``delta``.
+
+    Headers must follow ``chrom;start;end;...``. Lines that do not conform are
+    left unchanged.
+    """
+    tmp = fa_path.with_suffix(".tmp")
+    with open(fa_path) as fin, open(tmp, "w") as out:
+        for line in fin:
+            if line.startswith(">"):
+                parts = line[1:].strip().split(";")
+                if len(parts) >= 2:
+                    try:
+                        parts[1] = str(int(parts[1]) + delta)
+                        line = ">" + ";".join(parts) + "\n"
+                    except ValueError:
+                        pass
+            out.write(line)
+    os.replace(tmp, fa_path)
 
 
 def verify_fasta_file(path: str) -> None:

--- a/tests/test_module2_extract.py
+++ b/tests/test_module2_extract.py
@@ -12,4 +12,4 @@ def test_extract_sequences_names(tmp_path):
     out = tmp_path / "out.fa"
     _extract_sequences(fa, lifted, status, {}, out, 5)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
-    assert headers == [">chr1;11;20;+", ">chr1;31;40;-"]
+    assert headers == [">chr1;10;20;+", ">chr1;30;40;-"]


### PR DESCRIPTION
## Summary
- update fasta renaming to keep 0-based start coordinates
- shift FASTA header starts for module1 and module2 seqtk steps
- keep downstream coordinate handling consistent
- update tests for new header convention

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a694e2b883229678238bb55bb808