### PR TITLE
Add pyfaidx dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ conda config --add channels bioconda
 conda config --add channels conda-forge
 ```
 
-Install HapLongLINEr:
+Install HapLongLINEr along with `pyfaidx`:
 ```bash
-conda install haplongliner
+conda install haplongliner pyfaidx
 ```
 
 ### Using Git
@@ -43,7 +43,7 @@ Install HapLongLINEr with pip:
 ```bash
 cd HapLongLINEr
 
-pip install -e .
+pip install -e .  # installs pyfaidx automatically
 ```
 
 

--- a/haplongliner/recipe/meta.yaml
+++ b/haplongliner/recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     - pip
   run:
     - python
+    - pyfaidx
     - seqtk
     - minimap2
     - emboss
@@ -30,3 +31,4 @@ about:
   home: https://github.com/leiyangly/HapLongLINEr
   summary: "Pipeline for discovering and curating full-length young LINE-1 elements."
   license: MIT
+


### PR DESCRIPTION
## Summary
- document installing `pyfaidx` with conda
- show that pip install brings in pyfaidx automatically
- declare pyfaidx run requirement in the conda recipe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688824b6547483228c9c2c00c2a88d3b