### PR TITLE
Implement initial module 3 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,19 +116,26 @@ Output:
 - Log file (when using `-g/--log`) that summarizes results of each step of the pipeline module
 - FASTA file containing all full length (>=5kb by default) L1HS, L1PA2, and intact L1PA3 sequences from the input assembly
 
-### Module 3: Sequence Repository
+### Module 3: Sequence Retrieval
 
-Module 3 builds a sequence repository from previously identified insertions.
-Currently the only required argument is the output directory.
+Module 3 retrieves the sequences of L1 insertions present in the HPRC
+repository.  The user supplies a coordinate (``chr:start-end``) or a BED file of
+coordinates and the module outputs the corresponding L1 sequences.  Additional
+FASTA files from other individuals can be provided and will be appended to the
+resulting FASTA.
 
 Command:
 ```bash
-haplongliner db --out output_folder
+# Single coordinate
+haplongliner db -q chr1:1000-2000 -o out.fa
+
+# Coordinates from BED file with extra sequences
+haplongliner db -q sites.bed -e extra.fa -o out.fa
 ```
 
 Output:
-- Annotated BED file that adds the following columns to each L1 record: Frequency of presence in HPRC haploids; Intactness status in HPRC; Liftover coordinate in the chosen reference (hs1 or hg38)
-- FASTA file that Contains all L1 sequences at the insertion site from all HPRC haploids that carry that L1
+- FASTA file containing all L1 sequences found at the queried coordinates,
+  optionally combined with sequences from ``-e/--extra``.
 
 
 ## Authors

--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -201,11 +201,26 @@ def main():
         usage=argparse.SUPPRESS,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Usage:   haplongliner db [options]",
-        help="Module 3: L1 sequence repository",
+        help="Module 3: Retrieve L1 sequences by coordinate",
     )
     parser_db._positionals.title = ""
     parser_db._optionals.title = "Options"
-    parser_db.add_argument("-o", "--out", dest="output", required=True, help="Output directory or file")
+    parser_db.add_argument(
+        "-q",
+        "--query",
+        dest="query",
+        required=True,
+        help="Coordinate as chr:start-end or BED file",
+    )
+    parser_db.add_argument(
+        "-e",
+        "--extra",
+        dest="extra",
+        help="Additional FASTA with non-HPRC L1s",
+    )
+    parser_db.add_argument(
+        "-o", "--out", dest="output", required=True, help="Output FASTA file"
+    )
     parser_db.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS,
                            help="Show this help message and exit.")
 
@@ -272,7 +287,7 @@ def main():
             asm=args.asm,
         )
     elif args.command == "db":
-        run_module3(args.output)
+        run_module3(args.query, args.output, extra_fasta=args.extra)
 
     if log_handle:
         log_handle.close()

--- a/haplongliner/module3_DB.py
+++ b/haplongliner/module3_DB.py
@@ -1,3 +1,57 @@
-def run_module3(output):
-    print(f"Module 3 running with:\n  Output: {output}")
-    # TODO: Implement the actual logic here
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+import re
+
+from .utils import verify_bed_file, verify_fasta_file
+
+
+Coord = Tuple[str, int, int]
+
+
+def _parse_coords(query: str) -> List[Coord]:
+    """Return a list of ``(chrom, start, end)`` tuples from ``query``.
+
+    ``query`` may be a path to a BED-like file or a coordinate string in the
+    form ``chr:start-end``. Multiple coordinates can be separated by commas.
+    """
+    path = Path(query)
+    coords: List[Coord] = []
+    if path.exists():
+        verify_bed_file(str(path))
+        with open(path) as fh:
+            for line in fh:
+                if not line.strip() or line.startswith("#"):
+                    continue
+                chrom, start, end = line.strip().split()[:3]
+                coords.append((chrom, int(start), int(end)))
+        return coords
+
+    for token in query.split(','):
+        m = re.match(r"^([^:]+):(\d+)-(\d+)$", token.strip())
+        if not m:
+            raise ValueError(f"Invalid coordinate: {token}")
+        chrom, start, end = m.groups()
+        coords.append((chrom, int(start), int(end)))
+    return coords
+
+
+def run_module3(query: str, output: str, extra_fasta: str | None = None) -> None:
+    """Extract sequences for L1 insertions at ``query``.
+
+    ``query`` may be a BED file or ``chr:start-end`` string. ``output`` is the
+    path for the resulting FASTA file. If ``extra_fasta`` is provided, those
+    sequences will be appended to the extracted FASTA.
+    """
+    coords = _parse_coords(query)
+    print(
+        "Module 3 running with:\n"
+        f"  Coordinates: {coords}\n"
+        f"  Output: {output}"
+    )
+    if extra_fasta:
+        verify_fasta_file(extra_fasta)
+        print(f"  Extra FASTA: {extra_fasta}")
+    # TODO: implement extraction logic
+

--- a/tests/test_module3.py
+++ b/tests/test_module3.py
@@ -1,0 +1,19 @@
+from haplongliner.module3_DB import _parse_coords
+import pytest
+
+
+def test_parse_coords_string():
+    coords = _parse_coords("chr1:10-20")
+    assert coords == [("chr1", 10, 20)]
+
+
+def test_parse_coords_file(tmp_path):
+    bed = tmp_path / "sites.bed"
+    bed.write_text("chr2\t30\t40\nchr3\t50\t60\n")
+    coords = _parse_coords(str(bed))
+    assert coords == [("chr2", 30, 40), ("chr3", 50, 60)]
+
+
+def test_parse_coords_bad():
+    with pytest.raises(ValueError):
+        _parse_coords("badcoord")


### PR DESCRIPTION
## Summary
- flesh out `module3_DB.py` with coordinate parsing and stubbed extractor
- extend CLI to allow coordinate-based sequence retrieval
- document module 3 usage in README
- add simple tests for `_parse_coords`

## Testing
- `pip install pyfaidx`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888609d46a08322ba02de8dbe27cd34