### PR TITLE
Fix CLI dependency check for database mode

### DIFF
--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -249,10 +249,8 @@ def main():
         log_handle = open(args.log_file, "w")
         sys.stdout = _Tee(sys.stdout, log_handle)
 
-    if args.command:
-        check_dependencies()
-
     if args.command == "rm":
+        check_dependencies()
         # Determine reference path/URL
         if args.ref == "hs1":
             reference = HS1_URL
@@ -275,6 +273,7 @@ def main():
             reference = HS1_URL
         else:
             reference = HG38_URL
+        check_dependencies()
         run_module2(
             args.input,
             args.sv,

--- a/haplongliner/module3_DB.py
+++ b/haplongliner/module3_DB.py
@@ -84,7 +84,7 @@ def _load_database() -> Dict[str, List[Tuple[str, str]]]:
 def _load_reference(path: Path) -> str:
     fa = Fasta(str(path))
     first = next(iter(fa.records.values()))
-    return str(first.seq)
+    return str(first[:])
 
 
 Coord = Tuple[str, int, int]


### PR DESCRIPTION
## Summary
- check for external dependencies only for rm and sv modules
- fix reference FASTA reading

## Testing
- `pytest -q`
- `haplongliner db -q chr1:2000-3000 -o test_output_module3`


------
https://chatgpt.com/codex/tasks/task_e_68886b0bb5108322a1936fae6b98c0de