### PR TITLE
Fix missing edlib dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ setup(
     name="haplongliner",
     version="0.1.0",
     packages=find_packages(),
-    install_requires=["pyfaidx"],
+    install_requires=[
+        "pyfaidx",
+        "edlib",
+    ],
     entry_points={
         "console_scripts": [
             "haplongliner=haplongliner.cli:main"


### PR DESCRIPTION
## Summary
- add `edlib` to `setup.py` installation requirements so module3 works

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68891addf35c8322b9609497b07b23dd