### PR TITLE
Align module1 outputs with module2

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -91,8 +91,15 @@ def combine_table(
                     if int(end_ref) - int(start_ref) > 2 * min_length:
                         start_ref, end_ref = "NA", "NA"
 
+            ref_len = (
+                str(int(end_ref) - int(start_ref))
+                if start_ref != "NA" and end_ref != "NA"
+                else "NA"
+            )
+            target_info = f"{chr_ref};{start_ref};{end_ref};{ref_len};{out_strand};ALN"
+
             out.write(
-                f"{chrom}_{start}_{end}_{strand}_{dot}_{name}_{status}\t{chr_ref}_{start_ref}_{end_ref}_{out_strand}\n"
+                f"{chrom}\t{start}\t{end}\t{name}\t{dot}\t{strand}\t{status}\t{target_info}\n"
             )
 
 

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -134,6 +134,27 @@ def _extract_fasta(fa: Fasta, bed: Path, out: Path) -> None:
             out_f.write(f">{chrom};{start_i};{end_i};{strand}\n{seq}\n")
 
 
+def _write_rm_sequences(fasta: Path, bed: Path, out_fa: Path) -> None:
+    """Write sequences from ``fasta`` for each BED entry in ``bed``."""
+
+    fa = Fasta(str(fasta))
+    with open(bed) as b, open(out_fa, "w") as out:
+        for line in b:
+            if not line.strip() or line.startswith("#"):
+                continue
+            fields = line.strip().split()
+            if len(fields) < 6:
+                continue
+            chrom, start, end, *_rest, strand = fields[:6]
+            start_i = int(start)
+            end_i = int(end)
+            seq = fa[chrom][start_i:end_i].seq.upper()
+            if strand == "-":
+                seq = _revcomp(seq)
+            header = f"{chrom};{start_i};{end_i};{end_i - start_i};{strand};ALN"
+            out.write(f">{header}\n{seq}\n")
+
+
 def run_module1(
     input_fasta,
     repeatmasker_file,
@@ -305,8 +326,12 @@ def run_module1(
         min_length=min_length,
     )
 
+    print("\n[STEP 10] Writing candidate sequences")
+    rm_fa = outdir / "haplongliner_rm.fa"
+    _write_rm_sequences(Path(input_fasta), candidate_bed, rm_fa)
+
     # Final output table
-    print(f"Module 1 completed. Results in {combined_out}")
+    print(f"Module 1 completed. Results in {combined_out} and {rm_fa}")
 
     # Remove large intermediate files to save space
     # for tmp in [

--- a/tests/test_module1_fa.py
+++ b/tests/test_module1_fa.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from haplongliner.module1_RM import _write_rm_sequences
+
+
+def test_write_rm_sequences(tmp_path):
+    fa = tmp_path / "test.fa"
+    fa.write_text(">chr1\n" + "A" * 100 + "\n")
+    bed = tmp_path / "sites.bed"
+    bed.write_text("chr1\t10\t20\tL1a\t10\t+\nchr1\t30\t40\tL1b\t10\t-\n")
+    out = tmp_path / "rm.fa"
+    _write_rm_sequences(fa, bed, out)
+    headers = [l.strip() for l in open(out) if l.startswith(">")]
+    assert headers == [">chr1;10;20;10;+;ALN", ">chr1;30;40;10;-;ALN"]


### PR DESCRIPTION
## Summary
- output module1 FASTA sequences in the same format as module2
- produce a BED table with the same column structure as module2
- test new FASTA output helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a80eea864832287bb22976ffcb6c6