### PR TITLE
Fix module1 outputs

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -96,10 +96,13 @@ def combine_table(
                 if start_ref != "NA" and end_ref != "NA"
                 else "NA"
             )
-            target_info = f"{chr_ref};{start_ref};{end_ref};{ref_len};{out_strand};ALN"
+            # Coordinates in the final BED should use the reference (hs1)
+            # coordinates while the original scaffold information is stored in
+            # the last semicolon-delimited column.
+            scaffold_info = f"{chrom};{start};{end};{dot};{strand};RPM"
 
             out.write(
-                f"{chrom}\t{start}\t{end}\t{name}\t{dot}\t{strand}\t{status}\t{target_info}\n"
+                f"{chr_ref}\t{start_ref}\t{end_ref}\t{name}\t{ref_len}\t{out_strand}\t{status}\t{scaffold_info}\n"
             )
 
 

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -151,7 +151,7 @@ def _write_rm_sequences(fasta: Path, bed: Path, out_fa: Path) -> None:
             seq = fa[chrom][start_i:end_i].seq.upper()
             if strand == "-":
                 seq = _revcomp(seq)
-            header = f"{chrom};{start_i};{end_i};{end_i - start_i};{strand};ALN"
+            header = f"{chrom};{start_i};{end_i};{end_i - start_i};{strand};RPM"
             out.write(f">{header}\n{seq}\n")
 
 

--- a/tests/test_module1_fa.py
+++ b/tests/test_module1_fa.py
@@ -10,4 +10,4 @@ def test_write_rm_sequences(tmp_path):
     out = tmp_path / "rm.fa"
     _write_rm_sequences(fa, bed, out)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
-    assert headers == [">chr1;10;20;10;+;ALN", ">chr1;30;40;10;-;ALN"]
+    assert headers == [">chr1;10;20;10;+;RPM", ">chr1;30;40;10;-;RPM"]


### PR DESCRIPTION
## Summary
- output module1 FASTA headers with RPM label
- report scaffold info in column 8 of final table
- swap columns to use reference coordinates
- update module1 FASTA tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a889a650883229772e1824cd6d659