### PR TITLE
Allow long insertions as module2 candidates

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -231,6 +231,40 @@ def _bedtools_intersect(a: Path, b: Path, output: Path) -> None:
         )
 
 
+def _collect_long_insertions(
+    insertions: List[Tuple[str, int, int, str]],
+    inter_ins: Path,
+    min_length: int,
+) -> List[Tuple[str, int, int, str, str]]:
+    """Return insertion entries not overlapping lifted L1s with length >= ``min_length``.
+
+    The returned list contains tuples of ``(chrom, start, end, seq, name)`` where
+    ``name`` is generated from the coordinates (``INS_<chrom>_<start>``).
+    """
+
+    overlapped: Set[Tuple[str, int, int]] = set()
+    if inter_ins.exists():
+        with open(inter_ins) as fh:
+            for line in fh:
+                f = line.strip().split("\t")
+                if len(f) >= 12:
+                    try:
+                        chrom = f[8]
+                        start = int(f[9])
+                        end = int(f[10])
+                    except ValueError:
+                        continue
+                    overlapped.add((chrom, start, end))
+
+    extras: List[Tuple[str, int, int, str, str]] = []
+    for chrom, start, end, seq in insertions:
+        if len(seq) >= min_length and (chrom, start, end) not in overlapped:
+            name = f"INS_{chrom}_{start}"
+            extras.append((chrom, start, end, seq, name))
+
+    return extras
+
+
 def _classify_sv(
     lifted: List[Tuple[str, int, int, str, int, str, str, str, int, int]],
     deletions: List[Tuple[str, int, int]],
@@ -304,6 +338,7 @@ def _extract_sequences(
     ins_seqs: Dict[str, str],
     out_fa: Path,
     min_length: int,
+    extra_ins: List[Tuple[str, int, int, str, str]] | None = None,
 ) -> None:
     """Extract candidate L1 sequences from the target assembly."""
 
@@ -322,6 +357,12 @@ def _extract_sequences(
             if len(seq) >= min_length:
                 out.write(f">{name}_ins\n{seq}\n")
 
+        if extra_ins:
+            for chrom, start, end, seq, name in extra_ins:
+                if len(seq) >= min_length:
+                    header = f"{name};{chrom};{start};{end};."
+                    out.write(f">{header}\n{seq}\n")
+
 
 def _write_sv_sequences(
     fasta: Path,
@@ -329,10 +370,18 @@ def _write_sv_sequences(
     status: Dict[str, str],
     ins_seqs: Dict[str, str],
     out_fa: Path,
+    extra_ins: List[Tuple[str, int, int, str, str]] | None = None,
+    present: Set[str] | None = None,
+    intact: Set[str] | None = None,
 ) -> None:
     """Write sequences from the target assembly for ALN and INS entries."""
 
     fa = Fasta(str(fasta))
+    if present is None:
+        present = set()
+    if intact is None:
+        intact = set()
+    extras = extra_ins or []
 
     with open(out_fa, "w") as out:
         for (
@@ -368,6 +417,13 @@ def _write_sv_sequences(
                 seq = ins_seqs.get(name, "")
                 if seq:
                     out.write(f">{target_info}\n{seq}\n")
+
+        for chrom, start, end, seq, name in extras:
+            key = f"{name};{chrom};{start}"
+            if key not in present and key not in intact:
+                continue
+            target_info = f"{chrom};{start};{end};{end - start};.;INS"
+            out.write(f">{target_info}\n{seq}\n")
 
 
 def _parse_repeatmasker(out_file: Path, l1_len: int, cov_thresh: float) -> Set[str]:
@@ -596,19 +652,37 @@ def run_module2(
 
     status, ins_seqs = _classify_sv(lifted, deletions, insertions, outdir)
 
+    inter_ins = outdir / "intersect_ins.bed"
+    extra_ins = _collect_long_insertions(insertions, inter_ins, min_length)
+
     candidate_fa = outdir / "candidates.fa"
     _extract_sequences(
-        Path(input_fasta), lifted, status, ins_seqs, candidate_fa, min_length
+        Path(input_fasta),
+        lifted,
+        status,
+        ins_seqs,
+        candidate_fa,
+        min_length,
+        extra_ins,
     )
-
-    sv_fa = outdir / "haplongliner_sv.fa"
-    _write_sv_sequences(Path(input_fasta), lifted, status, ins_seqs, sv_fa)
 
     orf_present, intact_names = _validate_orfs(candidate_fa)
     # candidates.blastn determines presence status
     presence_names = _validate_presence(candidate_fa, min_length)
     # also mark sequences with >90% ORF coverage as present
     presence_names.update(orf_present)
+
+    sv_fa = outdir / "haplongliner_sv.fa"
+    _write_sv_sequences(
+        Path(input_fasta),
+        lifted,
+        status,
+        ins_seqs,
+        sv_fa,
+        extra_ins,
+        presence_names,
+        intact_names,
+    )
 
     print("\n[STEP 6] Writing output table")
 
@@ -654,6 +728,20 @@ def run_module2(
             target_info = f"{scaf};{t_start};{t_end};{target_len};{t_strand};{sv_stat}"
             out.write(
                 f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\t{final_stat}\t{target_info}\n"
+            )
+
+        for chrom, start, end, seq, name in extra_ins:
+            key = f"{name};{chrom};{start}"
+            if key in intact_names:
+                final_stat = "intact"
+            elif key in presence_names:
+                final_stat = "present"
+            else:
+                continue
+            target_len = end - start
+            target_info = f"{chrom};{start};{end};{target_len};.;INS"
+            out.write(
+                f"{chrom}\t{start}\t{end}\t{name}\t{target_len}\t.\t{final_stat}\t{target_info}\n"
             )
 
     print(f"Module 2 completed. Results in {out_table} and {sv_fa}")

--- a/tests/test_module2_collect.py
+++ b/tests/test_module2_collect.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from haplongliner.module2_SV import _collect_long_insertions
+
+
+def test_collect_long_insertions(tmp_path):
+    inter = tmp_path / "inter.bed"
+    inter.write_text("chr1\t0\t10\tL1\t6000\t+\tinfo\tinfo\tchr1\t100\t110\tAAAA\n")
+    insertions = [
+        ("chr1", 100, 110, "A" * 6000),
+        ("chr1", 200, 210, "T" * 6000),
+    ]
+    extras = _collect_long_insertions(insertions, inter, 5000)
+    assert extras == [("chr1", 200, 210, "T" * 6000, "INS_chr1_200")]

--- a/tests/test_module2_extract.py
+++ b/tests/test_module2_extract.py
@@ -13,3 +13,15 @@ def test_extract_sequences_names(tmp_path):
     _extract_sequences(fa, lifted, status, {}, out, 5)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
     assert headers == [">L1a;chr1;10;20;+", ">L1b;chr1;30;40;-"]
+
+
+def test_extract_sequences_with_extras(tmp_path):
+    fa = tmp_path / "test.fa"
+    fa.write_text(">chr1\n" + "A" * 100 + "\n")
+    lifted: list = []
+    status = {}
+    extras = [("chr1", 50, 70, "T" * 20, "INS_chr1_50")]
+    out = tmp_path / "extra.fa"
+    _extract_sequences(fa, lifted, status, {}, out, 5, extras)
+    headers = [l.strip() for l in open(out) if l.startswith(">")]
+    assert headers == [">INS_chr1_50;chr1;50;70;."]


### PR DESCRIPTION
## Summary
- treat insertion sequences >= threshold as extra candidates
- add `_collect_long_insertions` helper
- support extra insertions in `_extract_sequences`, `_write_sv_sequences`, and `run_module2`
- add tests for extracting and collecting insertion candidates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a891cf8c083229927bedb61debca0