### PR TITLE
Annotate novel insertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ haplongliner sv \
 ```
 
 Output:
-- OUT.TXT file with L1 info from your assembly and corresponding refence genome (hs1/hg38) coordinates and ORF status
+- OUT.TXT file (`haplongliner_sv.bed`) summarizing L1 coordinates and ORF status. Names from insertion calls that do not overlap lifted L1s end with `;nr`.
 - Log file (when using `-g/--log`) that summarizes results of each step of the pipeline module
 - FASTA file containing all full length (>=5kb by default) L1HS, L1PA2, and intact L1PA3 sequences from the input assembly
 

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -740,8 +740,10 @@ def run_module2(
                 continue
             target_len = end - start
             target_info = f"{chrom};{start};{end};{target_len};.;INS"
+            # mark non-reference insertions with a ';nr' suffix
+            name_out = f"{name};nr"
             out.write(
-                f"{chrom}\t{start}\t{end}\t{name}\t{target_len}\t.\t{final_stat}\t{target_info}\n"
+                f"{chrom}\t{start}\t{end}\t{name_out}\t{target_len}\t.\t{final_stat}\t{target_info}\n"
             )
 
     print(f"Module 2 completed. Results in {out_table} and {sv_fa}")


### PR DESCRIPTION
## Summary
- mark SV-derived insertions that do not overlap lifted L1s
- document the `;nr` suffix in the README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8f83af2c8322ad43c54920125b0c