### PR TITLE
Switch coordinate delimiters to commas

### DIFF
--- a/haplongliner/combine_table.py
+++ b/haplongliner/combine_table.py
@@ -17,7 +17,7 @@ def _read_intact(file_path: str) -> Dict[str, str]:
             if not line.strip():
                 continue
             fields = line.strip().split()
-            m = re.match(r"^(.+?)[;_](\d+)[;_](\d+)[;_]([+-])(?:[;_].*)?$", fields[0])
+            m = re.match(r"^(.+?)[,_](\d+)[,_](\d+)[,_]([+-])(?:[,_].*)?$", fields[0])
             if not m:
                 continue
             chrom, start, end, _ = m.groups()
@@ -53,8 +53,8 @@ def combine_table(
             p = end_i + 2000
             px = end_i
             mx = start_i
-            mkey = f"{chrom};{m};{start_i};{strand}"
-            pkey = f"{chrom};{px};{p};{strand}"
+            mkey = f"{chrom},{m},{start_i},{strand}"
+            pkey = f"{chrom},{px},{p},{strand}"
             # ORF headers now store 0-based coordinates
             ikey = f"{chrom}_{mx}_{end_i}"
 
@@ -99,7 +99,7 @@ def combine_table(
             # Coordinates in the final BED should use the reference (hs1)
             # coordinates while the original scaffold information is stored in
             # the last semicolon-delimited column.
-            scaffold_info = f"{chrom};{start};{end};{dot};{strand};RPM"
+            scaffold_info = f"{chrom},{start},{end},{dot},{strand},RPM"
 
             out.write(
                 f"{chr_ref}\t{start_ref}\t{end_ref}\t{name}\t{ref_len}\t{out_strand}\t{status}\t{scaffold_info}\n"

--- a/haplongliner/find_longest_orf.py
+++ b/haplongliner/find_longest_orf.py
@@ -17,7 +17,7 @@ def find_longest_orf(blastp_file, out_file):
             if not line.strip():
                 continue
             F = line.strip().split()
-            name = re.sub(r"[;_][0-9]+$", "", F[0])
+            name = re.sub(r"[,_][0-9]+$", "", F[0])
             subject = F[1]
             aln_len = int(F[3])
             if aln_len >= len_dict.get(name, {}).get(subject, 0):
@@ -28,9 +28,7 @@ def find_longest_orf(blastp_file, out_file):
     with open(out_file, "w") as out:
         for key in index:
             if "L1rpORF1p" in info.get(key, {}) and "L1rpORF2p" in info.get(key, {}):
-                out.write(
-                    f"{info[key]['L1rpORF1p']}\t{info[key]['L1rpORF2p']}\n"
-                )
+                out.write(f"{info[key]['L1rpORF1p']}\t{info[key]['L1rpORF2p']}\n")
 
 
 if __name__ == "__main__":

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -102,15 +102,13 @@ def download_if_needed(url, local_path):
     return str(local_path)
 
 
-
-
 def _fix_getorf_headers(fa_path: Path) -> None:
-    """Replace '_' before ORF indices with ';' in ``getorf`` FASTA headers."""
+    """Replace '_' before ORF indices with ',' in ``getorf`` FASTA headers."""
     tmp = fa_path.with_suffix(".tmp")
     with open(fa_path) as fin, open(tmp, "w") as out:
         for line in fin:
             if line.startswith(">"):
-                line = re.sub(r"^>([^\s]+)_([0-9]+)", r">\1;\2", line)
+                line = re.sub(r"^>([^\s]+)_([0-9]+)", r">\1,\2", line)
             out.write(line)
     os.replace(tmp, fa_path)
 
@@ -131,7 +129,7 @@ def _extract_fasta(fa: Fasta, bed: Path, out: Path) -> None:
             seq = fa[chrom][start_i:end_i].seq.upper()
             if strand == "-":
                 seq = _revcomp(seq)
-            out_f.write(f">{chrom};{start_i};{end_i};{strand}\n{seq}\n")
+            out_f.write(f">{chrom},{start_i},{end_i},{strand}\n{seq}\n")
 
 
 def _write_rm_sequences(fasta: Path, bed: Path, out_fa: Path) -> None:
@@ -151,7 +149,7 @@ def _write_rm_sequences(fasta: Path, bed: Path, out_fa: Path) -> None:
             seq = fa[chrom][start_i:end_i].seq.upper()
             if strand == "-":
                 seq = _revcomp(seq)
-            header = f"{chrom};{start_i};{end_i};{end_i - start_i};{strand};RPM"
+            header = f"{chrom},{start_i},{end_i},{end_i - start_i},{strand},RPM"
             out.write(f">{header}\n{seq}\n")
 
 

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -17,6 +17,7 @@ def _revcomp(seq: str) -> str:
     complement = str.maketrans("ACGTacgtNn", "TGCAtgcaNn")
     return seq.translate(complement)[::-1]
 
+
 from .module1_RM import download_if_needed
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
@@ -65,7 +66,7 @@ def _liftover_l1s(
     must contain the L1 coordinates on the reference assembly. The returned list
     contains tuples of ``(chrom, start, end, name, length, strand, plus_info,
     minus_info, t_start, t_end)`` where ``plus_info`` and ``minus_info`` are
-    ``scaffold;start;end;strand`` strings describing the lifted coordinates on
+    ``scaffold,start,end,strand`` strings describing the lifted coordinates on
     the target assembly.
 
     ``mapq``, ``min_align_len`` and ``max_div`` are forwarded to ``liftover_paf``
@@ -114,7 +115,7 @@ def _liftover_l1s(
         except ValueError:
             continue
         try:
-            _qchrom, q_start, q_end, _qstrand, q_name = name_field.split(";", 4)
+            _qchrom, q_start, q_end, _qstrand, q_name = name_field.split(",", 4)
         except ValueError:
             continue
 
@@ -125,7 +126,7 @@ def _liftover_l1s(
         if length < min_length:
             continue
 
-        plus_info = f"{t_chrom};{t_start};{t_end};{t_strand}"
+        plus_info = f"{t_chrom},{t_start},{t_end},{t_strand}"
         minus_info = plus_info
         lifted.append(
             (
@@ -346,11 +347,11 @@ def _extract_sequences(
 
     with open(out_fa, "w") as out:
         for _, _, _, name, _, _, plus_info, _, t_start, t_end in lifted:
-            scaf, _ps, _pe, t_strand = plus_info.split(";")
+            scaf, _ps, _pe, t_strand = plus_info.split(",")
             seq = fa[scaf][t_start:t_end].seq
             if t_strand == "-":
                 seq = _revcomp(seq)
-            header = f"{name};{scaf};{t_start};{t_end};{t_strand}"
+            header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
             out.write(f">{header}\n{seq}\n")
 
         for name, seq in ins_seqs.items():
@@ -360,7 +361,7 @@ def _extract_sequences(
         if extra_ins:
             for chrom, start, end, seq, name in extra_ins:
                 if len(seq) >= min_length:
-                    header = f"{name};{chrom};{start};{end};."
+                    header = f"{name},{chrom},{start},{end},."
                     out.write(f">{header}\n{seq}\n")
 
 
@@ -397,7 +398,7 @@ def _write_sv_sequences(
             t_end,
         ) in lifted:
             base_stat = status.get(name, "present")
-            scaf, *_rest, t_strand = plus_info.split(";")
+            scaf, *_rest, t_strand = plus_info.split(",")
 
             if name in ins_seqs:
                 sv_stat = "INS"
@@ -406,7 +407,9 @@ def _write_sv_sequences(
             else:
                 sv_stat = "ALN"
 
-            target_info = f"{scaf};{t_start};{t_end};{t_end - t_start};{t_strand};{sv_stat}"
+            target_info = (
+                f"{scaf},{t_start},{t_end},{t_end - t_start},{t_strand},{sv_stat}"
+            )
 
             if sv_stat == "ALN":
                 seq = fa[scaf][t_start:t_end].seq
@@ -419,10 +422,10 @@ def _write_sv_sequences(
                     out.write(f">{target_info}\n{seq}\n")
 
         for chrom, start, end, seq, name in extras:
-            key = f"{name};{chrom};{start}"
+            key = f"{name},{chrom},{start}"
             if key not in present and key not in intact:
                 continue
-            target_info = f"{chrom};{start};{end};{end - start};.;INS"
+            target_info = f"{chrom},{start},{end},{end - start},.,INS"
             out.write(f">{target_info}\n{seq}\n")
 
 
@@ -495,7 +498,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             if len(fields) < 30:
                 continue
             name = re.sub(r"_[0-9]+$", "", fields[0])
-            name = ";".join(name.split(";")[:3])
+            name = ",".join(name.split(",")[:3])
             try:
                 cov1 = int(fields[3]) / int(fields[13])
                 cov2 = int(fields[18]) / int(fields[28])
@@ -512,7 +515,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             if len(fields) < 30:
                 continue
             name = re.sub(r"_[0-9]+$", "", fields[0])
-            name = ";".join(name.split(";")[:3])
+            name = ",".join(name.split(",")[:3])
             intact.add(name)
 
     return present, intact
@@ -550,7 +553,7 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
             if len(f) < 14:
                 continue
             name = re.sub(r"_[0-9]+$", "", f[0])
-            name = ";".join(name.split(";")[:3])
+            name = ",".join(name.split(",")[:3])
             try:
                 length = int(f[3])
             except ValueError:
@@ -701,7 +704,7 @@ def run_module2(
             t_end,
         ) in lifted:
             base_stat = status.get(name, "present")
-            scaf, *_rest, t_strand = plus_info.split(";")
+            scaf, *_rest, t_strand = plus_info.split(",")
             target_len = t_end - t_start
 
             # Presence is determined solely by candidates.blastn and
@@ -709,7 +712,7 @@ def run_module2(
             # candidates.intact.blastp is labeled "intact"; those only in
             # candidates.blastn are labeled "present". Everything else is
             # considered "absent".
-            key = f"{name};{scaf};{t_start}"
+            key = f"{name},{scaf},{t_start}"
 
             if key in intact_names:
                 final_stat = "intact"
@@ -725,13 +728,13 @@ def run_module2(
             else:
                 sv_stat = "ALN"
 
-            target_info = f"{scaf};{t_start};{t_end};{target_len};{t_strand};{sv_stat}"
+            target_info = f"{scaf},{t_start},{t_end},{target_len},{t_strand},{sv_stat}"
             out.write(
                 f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\t{final_stat}\t{target_info}\n"
             )
 
         for chrom, start, end, seq, name in extra_ins:
-            key = f"{name};{chrom};{start}"
+            key = f"{name},{chrom},{start}"
             if key in intact_names:
                 final_stat = "intact"
             elif key in presence_names:
@@ -739,7 +742,7 @@ def run_module2(
             else:
                 continue
             target_len = end - start
-            target_info = f"{chrom};{start};{end};{target_len};.;INS"
+            target_info = f"{chrom},{start},{end},{target_len},.,INS"
             # mark non-reference insertions with a ';nr' suffix
             name_out = f"{name};nr"
             out.write(

--- a/haplongliner/module3_DB.py
+++ b/haplongliner/module3_DB.py
@@ -108,7 +108,7 @@ def _parse_coords(query: str) -> List[Coord]:
                 coords.append((chrom, int(start), int(end)))
         return coords
 
-    for token in query.split(','):
+    for token in query.split(","):
         m = re.match(r"^([^:]+):(\d+)-(\d+)$", token.strip())
         if not m:
             raise ValueError(f"Invalid coordinate: {token}")
@@ -125,11 +125,7 @@ def run_module3(query: str, output: str, extra_fasta: str | None = None) -> None
     sequences will be appended to the extracted FASTA.
     """
     coords = _parse_coords(query)
-    print(
-        "Module 3 running with:\n"
-        f"  Coordinates: {coords}\n"
-        f"  Output: {output}"
-    )
+    print("Module 3 running with:\n" f"  Coordinates: {coords}\n" f"  Output: {output}")
     if extra_fasta:
         verify_fasta_file(extra_fasta)
         print(f"  Extra FASTA: {extra_fasta}")
@@ -154,7 +150,11 @@ def run_module3(query: str, output: str, extra_fasta: str | None = None) -> None
 
     with open(output, "w") as out_f:
         for chrom, qstart, qend in coords:
-            hits = [e for e in by_chrom.get(chrom, []) if not (qend <= e[0] or qstart >= e[1])]
+            hits = [
+                e
+                for e in by_chrom.get(chrom, [])
+                if not (qend <= e[0] or qstart >= e[1])
+            ]
             if not hits:
                 print(
                     f"No L1 in hs1 at {chrom}:{qstart}-{qend}. Use -e/--extra to add sequences."
@@ -167,11 +167,10 @@ def run_module3(query: str, output: str, extra_fasta: str | None = None) -> None
                     continue
                 for rid, seq in records:
                     orient, cigar = _best_alignment(seq, ref_seq)
-                    header = f">{rid};{chrom}:{start}-{end};{orient};{cigar}"
+                    header = f">{rid},{chrom}:{start}-{end},{orient},{cigar}"
                     out_f.write(header + "\n" + seq + "\n")
 
         if extra_fasta:
             with open(extra_fasta) as fh:
                 for line in fh:
                     out_f.write(line)
-

--- a/haplongliner/process_orf.py
+++ b/haplongliner/process_orf.py
@@ -27,15 +27,13 @@ def process_orf_fasta(in_fasta, out_bed):
             strand = "+" if pos_end >= pos_start else "-"
 
             header = fields[0][1:]
-            m = re.match(r"^(.+?)[;_](\d+)[;_](\d+)[;_]([+-])(?:[;_].*)?$", header)
+            m = re.match(r"^(.+?)[,_](\d+)[,_](\d+)[,_]([+-])(?:[,_].*)?$", header)
             if not m:
                 continue
             chrom, lstart, lend, l1_strand = m.groups()
             l1_id = f"{chrom}_{lstart}_{lend}"
             length = end - start
-            fout.write(
-                f"{l1_id}\t{start}\t{end}\t{strand}\t{length}\t{l1_strand}\n"
-            )
+            fout.write(f"{l1_id}\t{start}\t{end}\t{strand}\t{length}\t{l1_strand}\n")
 
 
 if __name__ == "__main__":

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
+
 def check_dependencies():
     """Ensure required external tools are available."""
     tools = ["minimap2", "getorf", "blastp"]
@@ -57,18 +58,18 @@ def run_quiet(cmd, **kwargs):
 def shift_fasta_start(fa_path: Path, delta: int = -1) -> None:
     """Adjust start coordinate in FASTA headers by ``delta``.
 
-    Headers must follow ``chrom;start;end;...``. Lines that do not conform are
+    Headers must follow ``chrom,start,end,...``. Lines that do not conform are
     left unchanged.
     """
     tmp = fa_path.with_suffix(".tmp")
     with open(fa_path) as fin, open(tmp, "w") as out:
         for line in fin:
             if line.startswith(">"):
-                parts = line[1:].strip().split(";")
+                parts = line[1:].strip().split(",")
                 if len(parts) >= 2:
                     try:
                         parts[1] = str(int(parts[1]) + delta)
-                        line = ">" + ";".join(parts) + "\n"
+                        line = ">" + ",".join(parts) + "\n"
                     except ValueError:
                         pass
             out.write(line)
@@ -154,7 +155,7 @@ def read_paf(path: str | Path) -> Dict[str, List[str]]:
         for line in fh:
             if not line.strip():
                 continue
-            fields = line.rstrip().split('\t')
+            fields = line.rstrip().split("\t")
             if len(fields) < 4:
                 continue
             qname = fields[0]

--- a/scripts/liftover_paf.py
+++ b/scripts/liftover_paf.py
@@ -124,7 +124,12 @@ def read_bed(path: str | None, to_merge: bool) -> Dict[str, Interval]:
 
 
 def liftover_paf(
-    paf_path: str, bed_path: str, min_mapq: int, min_len: int, max_div: float, merge: bool
+    paf_path: str,
+    bed_path: str,
+    min_mapq: int,
+    min_len: int,
+    max_div: float,
+    merge: bool,
 ) -> None:
     bed = read_bed(bed_path, merge)
     fh = sys.stdin if paf_path == "-" else open(paf_path)
@@ -212,10 +217,10 @@ def liftover_paf(
                 y += length
                 if op == "M":
                     x += length
-            if x != t[8] or (
-                strand == "+" and y != t[3]
-            ) or (
-                strand == "-" and y != t[1] - t[2]
+            if (
+                x != t[8]
+                or (strand == "+" and y != t[3])
+                or (strand == "-" and y != t[1] - t[2])
             ):
                 raise RuntimeError("CIGAR is inconsistent with mapping coordinates")
 
@@ -225,17 +230,21 @@ def liftover_paf(
                 else:
                     r[idx][1] = coord + 1
             for i, (s, e, b_strand, b_name, b_score, *_) in enumerate(regs):
-                name = f"{t[0]};{s};{e};{b_strand};{b_name}"
+                name = f"{t[0]},{s},{e},{b_strand},{b_name}"
                 start = r[i][0]
                 end = r[i][1]
                 if start < 0:
-                    name += ";t5"
+                    name += ",t5"
                     start = t[7]
                 if end < 0:
-                    name += ";t3"
+                    name += ",t3"
                     end = t[8]
                 out_strand = t[4] if b_strand == "+" else ("+" if t[4] == "-" else "-")
-                print("\t".join([t[5], str(start), str(end), name, str(b_score), out_strand]))
+                print(
+                    "\t".join(
+                        [t[5], str(start), str(end), name, str(b_score), out_strand]
+                    )
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_liftover.py
+++ b/tests/test_liftover.py
@@ -10,48 +10,54 @@ def write_paf(path: Path, lines: list[str]) -> None:
 def test_read_paf_filters_and_selects_longest(tmp_path):
     paf = tmp_path / "test.paf"
     lines = [
-        "\t".join([
-            "q1",
-            "1000",
-            "0",
-            "180",
-            "+",
-            "chr1",
-            "10000",
-            "0",
-            "180",
-            "180",
-            "180",
-            "60",
-        ]),
-        "\t".join([
-            "q1",
-            "1000",
-            "0",
-            "400",
-            "+",
-            "chr1",
-            "10000",
-            "200",
-            "600",
-            "400",
-            "400",
-            "60",
-        ]),
-        "\t".join([
-            "q2",
-            "1000",
-            "0",
-            "150",
-            "+",
-            "chr1",
-            "10000",
-            "0",
-            "150",
-            "150",
-            "150",
-            "60",
-        ]),
+        "\t".join(
+            [
+                "q1",
+                "1000",
+                "0",
+                "180",
+                "+",
+                "chr1",
+                "10000",
+                "0",
+                "180",
+                "180",
+                "180",
+                "60",
+            ]
+        ),
+        "\t".join(
+            [
+                "q1",
+                "1000",
+                "0",
+                "400",
+                "+",
+                "chr1",
+                "10000",
+                "200",
+                "600",
+                "400",
+                "400",
+                "60",
+            ]
+        ),
+        "\t".join(
+            [
+                "q2",
+                "1000",
+                "0",
+                "150",
+                "+",
+                "chr1",
+                "10000",
+                "0",
+                "150",
+                "150",
+                "150",
+                "60",
+            ]
+        ),
     ]
     write_paf(paf, lines)
     hits = _read_paf(paf)
@@ -66,51 +72,49 @@ def test_liftover_l1s_plus_and_minus(tmp_path):
     master = tmp_path / "master.bed"
 
     paf_lines = [
-        "\t".join([
-            "chrA",
-            "1000",
-            "0",
-            "1000",
-            "+",
-            "chrX",
-            "10000",
-            "1200",
-            "2200",
-            "1000",
-            "1000",
-            "60",
-            "tp:A:P",
-            "cg:Z:1000M",
-        ]),
-        "\t".join([
-            "chrB",
-            "1000",
-            "0",
-            "100",
-            "+",
-            "chrY",
-            "10000",
-            "300",
-            "400",
-            "100",
-            "100",
-            "60",
-            "tp:A:P",
-            "cg:Z:100M",
-        ]),
+        "\t".join(
+            [
+                "chrA",
+                "1000",
+                "0",
+                "1000",
+                "+",
+                "chrX",
+                "10000",
+                "1200",
+                "2200",
+                "1000",
+                "1000",
+                "60",
+                "tp:A:P",
+                "cg:Z:1000M",
+            ]
+        ),
+        "\t".join(
+            [
+                "chrB",
+                "1000",
+                "0",
+                "100",
+                "+",
+                "chrY",
+                "10000",
+                "300",
+                "400",
+                "100",
+                "100",
+                "60",
+                "tp:A:P",
+                "cg:Z:100M",
+            ]
+        ),
     ]
 
     write_paf(paf, paf_lines)
 
-    ref_bed.write_text(
-        "chrA\t100\t900\tL1a\t+\n" +
-        "chrB\t0\t100\tL1b\t-\n"
-    )
+    ref_bed.write_text("chrA\t100\t900\tL1a\t+\n" + "chrB\t0\t100\tL1b\t-\n")
 
-    master.write_text(
-        "chrA\t100\t1000\tL1a\t+\n" +
-        "chrB\t0\t100\tL1b\t-\n"
-    )
+    master.write_text("chrA\t100\t1000\tL1a\t+\n" + "chrB\t0\t100\tL1b\t-\n")
 
     lifted = _liftover_l1s(paf, ref_bed, min_length=50, master_files=[master])
     lifted.sort(key=lambda x: x[3])
@@ -122,8 +126,8 @@ def test_liftover_l1s_plus_and_minus(tmp_path):
         "L1a",
         900,
         "+",
-        "chrX;1300;2100;+",
-        "chrX;1300;2100;+",
+        "chrX,1300,2100,+",
+        "chrX,1300,2100,+",
         1300,
         2100,
     )
@@ -134,8 +138,8 @@ def test_liftover_l1s_plus_and_minus(tmp_path):
         "L1b",
         100,
         "-",
-        "chrY;300;400;+",
-        "chrY;300;400;+",
+        "chrY,300,400,+",
+        "chrY,300,400,+",
         300,
         400,
     )
@@ -147,22 +151,24 @@ def test_liftover_respects_min_length(tmp_path):
     master = tmp_path / "master.bed"
 
     paf.write_text(
-        "\t".join([
-            "chrC",
-            "1000",
-            "0",
-            "80",
-            "+",
-            "scaf1",
-            "10000",
-            "2000",
-            "2080",
-            "80",
-            "80",
-            "60",
-            "tp:A:P",
-            "cg:Z:80M",
-        ])
+        "\t".join(
+            [
+                "chrC",
+                "1000",
+                "0",
+                "80",
+                "+",
+                "scaf1",
+                "10000",
+                "2000",
+                "2080",
+                "80",
+                "80",
+                "60",
+                "tp:A:P",
+                "cg:Z:80M",
+            ]
+        )
         + "\n"
     )
 

--- a/tests/test_liftover_paf_strand.py
+++ b/tests/test_liftover_paf_strand.py
@@ -10,17 +10,20 @@ spec = importlib.util.spec_from_file_location(
 liftover_paf = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(liftover_paf)
 
+
 def test_liftover_respects_strand(tmp_path, capsys):
     paf = tmp_path / "test.paf"
     bed = tmp_path / "test.bed"
-    paf.write_text("q1\t1000\t100\t200\t+\tchr1\t2000\t1000\t1100\t100\t100\t60\ttp:A:P\tcg:Z:100M\n")
+    paf.write_text(
+        "q1\t1000\t100\t200\t+\tchr1\t2000\t1000\t1100\t100\t100\t60\ttp:A:P\tcg:Z:100M\n"
+    )
     bed.write_text("q1\t110\t130\tname1\t0\t+\nq1\t140\t150\tname2\t0\t-\n")
     liftover_paf.liftover_paf(str(paf), str(bed), 0, 0, 2.0, False)
     out = capsys.readouterr().out.strip().splitlines()
     f1 = out[0].split("\t")
     f2 = out[1].split("\t")
-    assert f1[3] == "q1;110;130;+;name1"
-    assert f2[3] == "q1;140;150;-;name2"
+    assert f1[3] == "q1,110,130,+,name1"
+    assert f2[3] == "q1,140,150,-,name2"
     assert f1[4] == "0"
     assert f2[4] == "0"
     assert f1[5] == "+"

--- a/tests/test_module1_fa.py
+++ b/tests/test_module1_fa.py
@@ -10,4 +10,4 @@ def test_write_rm_sequences(tmp_path):
     out = tmp_path / "rm.fa"
     _write_rm_sequences(fa, bed, out)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
-    assert headers == [">chr1;10;20;10;+;RPM", ">chr1;30;40;10;-;RPM"]
+    assert headers == [">chr1,10,20,10,+,RPM", ">chr1,30,40,10,-,RPM"]

--- a/tests/test_module2_extract.py
+++ b/tests/test_module2_extract.py
@@ -1,18 +1,19 @@
 from pathlib import Path
 from haplongliner.module2_SV import _extract_sequences
 
+
 def test_extract_sequences_names(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted = [
-        ("chr1", 10, 20, "L1a", 10, "+", "chr1;10;20;+", "chr1;10;20;+", 10, 20),
-        ("chr1", 30, 40, "L1b", 10, "-", "chr1;30;40;-", "chr1;30;40;-", 30, 40),
+        ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
+        ("chr1", 30, 40, "L1b", 10, "-", "chr1,30,40,-", "chr1,30,40,-", 30, 40),
     ]
     status = {"L1a": "present", "L1b": "present"}
     out = tmp_path / "out.fa"
     _extract_sequences(fa, lifted, status, {}, out, 5)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
-    assert headers == [">L1a;chr1;10;20;+", ">L1b;chr1;30;40;-"]
+    assert headers == [">L1a,chr1,10,20,+", ">L1b,chr1,30,40,-"]
 
 
 def test_extract_sequences_with_extras(tmp_path):
@@ -24,4 +25,4 @@ def test_extract_sequences_with_extras(tmp_path):
     out = tmp_path / "extra.fa"
     _extract_sequences(fa, lifted, status, {}, out, 5, extras)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
-    assert headers == [">INS_chr1_50;chr1;50;70;."]
+    assert headers == [">INS_chr1_50,chr1,50,70,."]

--- a/tests/test_module2_sv_fa.py
+++ b/tests/test_module2_sv_fa.py
@@ -6,12 +6,12 @@ def test_write_sv_sequences(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted = [
-        ("chr1", 10, 20, "L1a", 10, "+", "chr1;10;20;+", "chr1;10;20;+", 10, 20),
-        ("chr1", 30, 40, "L1b", 10, "+", "chr1;30;40;+", "chr1;30;40;+", 30, 40),
+        ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
+        ("chr1", 30, 40, "L1b", 10, "+", "chr1,30,40,+", "chr1,30,40,+", 30, 40),
     ]
     status = {"L1a": "present", "L1b": "present"}
     ins_seqs = {"L1b": "T" * 10}
     out = tmp_path / "sv.fa"
     _write_sv_sequences(fa, lifted, status, ins_seqs, out)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
-    assert headers == [">chr1;10;20;10;+;ALN", ">chr1;30;40;10;+;INS"]
+    assert headers == [">chr1,10,20,10,+,ALN", ">chr1,30,40,10,+,INS"]


### PR DESCRIPTION
## Summary
- use commas instead of semicolons when encoding coordinate subfields
- update parsing logic to handle comma separated coordinates
- update test expectations for new delimiter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b0e6153048322872f4cdd8c9984d6