### PR TITLE
Fix blastn call with empty FASTA entries

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -628,13 +628,48 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
     if candidate_fa.stat().st_size == 0:
         return present
 
+    # remove FASTA headers that have no sequence lines before running BLASTN
+    cleaned_fa = candidate_fa
+    removed: List[str] = []
+    records: List[str] = []
+    header: str | None = None
+    seq_lines: List[str] = []
+    with open(candidate_fa) as fh:
+        for line in fh:
+            if line.startswith('>'):
+                if header is not None:
+                    if seq_lines:
+                        records.append(header)
+                        records.extend(seq_lines)
+                    else:
+                        removed.append(header[1:].strip())
+                header = line
+                seq_lines = []
+            else:
+                seq_lines.append(line)
+        if header is not None:
+            if seq_lines:
+                records.append(header)
+                records.extend(seq_lines)
+            else:
+                removed.append(header[1:].strip())
+
+    if removed:
+        cleaned_fa = candidate_fa.with_suffix('.clean.fa')
+        with open(cleaned_fa, 'w') as out:
+            out.writelines(records)
+        print(f"Warning: ignoring empty FASTA entries: {', '.join(removed)}")
+
+    if cleaned_fa.stat().st_size == 0:
+        return present
+
     blastn_out = candidate_fa.with_suffix(".blastn")
     ref_fa = Path("data") / "L1rp.fa"
     run_quiet(
         [
             "blastn",
             "-query",
-            str(candidate_fa),
+            str(cleaned_fa),
             "-subject",
             str(ref_fa),
             "-outfmt",

--- a/tests/test_module2_presence.py
+++ b/tests/test_module2_presence.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from haplongliner.module2_SV import _validate_presence
+
+
+def test_validate_presence_ignores_empty(tmp_path, monkeypatch):
+    fa = tmp_path / "cand.fa"
+    # one entry with no sequence, one valid entry
+    fa.write_text(">empty\n>ok\nATGC\n")
+
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        calls['cmd'] = cmd
+        out_idx = cmd.index('-out') + 1
+        Path(cmd[out_idx]).write_text("")
+        class Dummy:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+            def check_returncode(self):
+                pass
+        return Dummy()
+
+    monkeypatch.setattr("haplongliner.module2_SV.run_quiet", fake_run)
+    names = _validate_presence(fa, min_length=1)
+    assert names == set()
+    assert 'cmd' in calls
+    q_idx = calls['cmd'].index('-query') + 1
+    q_path = Path(calls['cmd'][q_idx])
+    q_text = q_path.read_text()
+    assert '>empty' not in q_text
+    assert '>ok' in q_text


### PR DESCRIPTION
## Summary
- skip empty FASTA entries before running BLASTN
- run BLASTN on the cleaned FASTA
- add regression test for empty FASTA entries

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c033253608322a9eb0d28ea84f553