### PR TITLE
Fix writing empty sequences in module 2

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -452,8 +452,9 @@ def _extract_sequences(
             seq = fa[scaf][t_start:t_end].seq
             if t_strand == "-":
                 seq = _revcomp(seq)
-            header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
-            out.write(f">{header}\n{seq}\n")
+            if seq:
+                header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
+                out.write(f">{header}\n{seq}\n")
 
         for name, seq in ins_seqs.items():
             if len(seq) >= min_length:


### PR DESCRIPTION
## Summary
- avoid writing empty sequences when assembling `candidates.fa`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c39692edc8322a58cffdef6ddd326