### PR TITLE
Fix getorf header format

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -103,12 +103,24 @@ def download_if_needed(url, local_path):
 
 
 def _fix_getorf_headers(fa_path: Path) -> None:
-    """Replace '_' before ORF indices with ',' in ``getorf`` FASTA headers."""
+    """Rewrite ``getorf`` FASTA headers for easier downstream parsing.
+
+    ``getorf`` produces headers in the form ``>name_<idx> [<s> - <e>]``.  This
+    function converts them to ``>name,<idx>,<s>,<e>`` so the different fields can
+    be reliably retrieved by simply splitting on commas.  ``name`` itself may
+    contain underscores (e.g. scaffold identifiers), so only the separators
+    introduced by ``getorf`` are replaced.
+    """
+
     tmp = fa_path.with_suffix(".tmp")
+    pattern = re.compile(r"^>([^\s]+)_([0-9]+)\s+\[([0-9]+)\s*-\s*([0-9]+)\]")
     with open(fa_path) as fin, open(tmp, "w") as out:
         for line in fin:
             if line.startswith(">"):
-                line = re.sub(r"^>([^\s]+)_([0-9]+)", r">\1,\2", line)
+                m = pattern.match(line)
+                if m:
+                    name, idx, start, end = m.groups()
+                    line = f">{name},{idx},{start},{end}\n"
             out.write(line)
     os.replace(tmp, fa_path)
 

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -34,7 +34,7 @@ def _parse_target_info(info: str) -> Tuple[str, int, int, str]:
     return scaf, start, end, strand
 
 
-from .module1_RM import download_if_needed
+from .module1_RM import download_if_needed, _fix_getorf_headers
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
 
@@ -567,6 +567,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
         ],
         check=True,
     )
+    _fix_getorf_headers(orf_fa)
 
     blastp_out = candidate_fa.with_suffix(".blastp")
     db_prefix = Path("data") / "L1rpORF12p.fa"
@@ -599,8 +600,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             fields = line.strip().split()
             if len(fields) < 30:
                 continue
-            name = re.sub(r"_[0-9]+$", "", fields[0])
-            name = ",".join(name.split(",")[:3])
+            name = ",".join(fields[0].split(",")[:3])
             try:
                 cov1 = int(fields[3]) / int(fields[13])
                 cov2 = int(fields[18]) / int(fields[28])
@@ -616,8 +616,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             fields = line.strip().split()
             if len(fields) < 30:
                 continue
-            name = re.sub(r"_[0-9]+$", "", fields[0])
-            name = ",".join(name.split(",")[:3])
+            name = ",".join(fields[0].split(",")[:3])
             intact.add(name)
 
     return present, intact
@@ -654,8 +653,7 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
             f = line.strip().split()
             if len(f) < 14:
                 continue
-            name = re.sub(r"_[0-9]+$", "", f[0])
-            name = ",".join(name.split(",")[:3])
+            name = ",".join(f[0].split(",")[:3])
             try:
                 length = int(f[3])
             except ValueError:

--- a/tests/test_module1_fa.py
+++ b/tests/test_module1_fa.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from haplongliner.module1_RM import _write_rm_sequences
+from haplongliner.module1_RM import _write_rm_sequences, _fix_getorf_headers
 
 
 def test_write_rm_sequences(tmp_path):
@@ -11,3 +11,13 @@ def test_write_rm_sequences(tmp_path):
     _write_rm_sequences(fa, bed, out)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
     assert headers == [">chr1,10,20,10,+,RPM", ">chr1,30,40,10,-,RPM"]
+
+
+def test_fix_getorf_headers(tmp_path):
+    fa = tmp_path / "orf.fa"
+    fa.write_text(
+        ">scaf_A_B_1 [5 - 10]\nAAAA\n>name_2 [1 - 2]\nTT\n"
+    )
+    _fix_getorf_headers(fa)
+    headers = [l.strip() for l in open(fa) if l.startswith(">")]
+    assert headers == [">scaf_A_B,1,5,10", ">name,2,1,2"]


### PR DESCRIPTION
## Summary
- update `_fix_getorf_headers` to convert `getorf` headers into comma separated format with ORF coordinates
- ensure module2 calls `_fix_getorf_headers` and parse updated names
- test new header function

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c6fba07508322a7b54432527ec2bd