### PR TITLE
Fix ORF header parsing

### DIFF
--- a/haplongliner/process_orf.py
+++ b/haplongliner/process_orf.py
@@ -10,15 +10,39 @@ def process_orf_fasta(in_fasta, out_bed):
         l1_id  start  end  strand  length  l1_strand
     """
 
+    pattern_new = re.compile(r"^(.+),(\d+),(\d+),(\d+)$")
+    pattern_old = re.compile(r"^(.+?)[,_](\d+)[,_](\d+)[,_]([+-])(?:[,_].*)?$")
+
     with open(in_fasta) as fin, open(out_bed, "w") as fout:
         for line in fin:
             if not line.startswith(">"):
                 continue
-            fields = line.strip().split()
-            if len(fields) < 4:
-                continue
-            pos_start = int(fields[1].lstrip("["))
-            pos_end = int(fields[3].rstrip("]"))
+            line = line.strip()
+
+            header = line[1:]
+            m_new = pattern_new.match(header)
+            if m_new:
+                base, idx, pos_start, pos_end = m_new.groups()
+                pos_start = int(pos_start)
+                pos_end = int(pos_end)
+                parts = base.split(",")
+                if len(parts) >= 5:
+                    chrom, lstart, lend, _length, l1_strand = parts[:5]
+                else:
+                    # Fallback: derive values from the tail of the list
+                    chrom, lstart, lend = parts[0], parts[1], parts[2]
+                    l1_strand = parts[-1]
+            else:
+                fields = line.split()
+                if len(fields) < 4:
+                    continue
+                pos_start = int(fields[1].lstrip("["))
+                pos_end = int(fields[3].rstrip("]"))
+                header = fields[0][1:]
+                m_old = pattern_old.match(header)
+                if not m_old:
+                    continue
+                chrom, lstart, lend, l1_strand = m_old.groups()
 
             # getorf reports coordinates as 1-based inclusive. Convert to
             # 0-based half-open to match the rest of the pipeline.
@@ -26,11 +50,6 @@ def process_orf_fasta(in_fasta, out_bed):
             end = max(pos_start, pos_end)
             strand = "+" if pos_end >= pos_start else "-"
 
-            header = fields[0][1:]
-            m = re.match(r"^(.+?)[,_](\d+)[,_](\d+)[,_]([+-])(?:[,_].*)?$", header)
-            if not m:
-                continue
-            chrom, lstart, lend, l1_strand = m.groups()
             l1_id = f"{chrom}_{lstart}_{lend}"
             length = end - start
             fout.write(f"{l1_id}\t{start}\t{end}\t{strand}\t{length}\t{l1_strand}\n")

--- a/tests/test_process_orf.py
+++ b/tests/test_process_orf.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from haplongliner.process_orf import process_orf_fasta
+
+
+def test_process_orf_fasta(tmp_path):
+    fa = tmp_path / "orf.fa"
+    fa.write_text(
+        ">chr1,10,20,10,+,RPM,1,5,10\nAA\n"
+        ">chr2,30,40,10,-,RPM,2,3,8\nTT\n"
+        ">chr3,50,60,10,+,RPM,3,9,4\nCC\n"
+    )
+    bed = tmp_path / "out.bed"
+    process_orf_fasta(fa, bed)
+    lines = [l.strip() for l in open(bed)]
+    assert lines == [
+        "chr1_10_20\t4\t10\t+\t6\t+",
+        "chr2_30_40\t2\t8\t+\t6\t-",
+        "chr3_50_60\t3\t9\t-\t6\t+",
+    ]


### PR DESCRIPTION
## Summary
- handle new getorf header format when making candidate_orf.bed
- add regression test for process_orf_fasta

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c790d9c608322a1f75bef7a1eee10