### PR TITLE
Fix ORF header parser crash

### DIFF
--- a/haplongliner/process_orf.py
+++ b/haplongliner/process_orf.py
@@ -28,10 +28,13 @@ def process_orf_fasta(in_fasta, out_bed):
                 parts = base.split(",")
                 if len(parts) >= 5:
                     chrom, lstart, lend, _length, l1_strand = parts[:5]
-                else:
+                elif len(parts) >= 3:
                     # Fallback: derive values from the tail of the list
                     chrom, lstart, lend = parts[0], parts[1], parts[2]
                     l1_strand = parts[-1]
+                else:
+                    # Skip headers that do not contain enough fields
+                    continue
             else:
                 fields = line.split()
                 if len(fields) < 4:

--- a/tests/test_process_orf.py
+++ b/tests/test_process_orf.py
@@ -17,3 +17,12 @@ def test_process_orf_fasta(tmp_path):
         "chr2_30_40\t2\t8\t+\t6\t-",
         "chr3_50_60\t3\t9\t-\t6\t+",
     ]
+
+
+def test_process_orf_fasta_invalid(tmp_path):
+    """Headers missing required fields should be ignored."""
+    fa = tmp_path / "bad_orf.fa"
+    fa.write_text(">bad_header\nAA\n")
+    bed = tmp_path / "out.bed"
+    process_orf_fasta(fa, bed)
+    assert bed.read_text() == ""


### PR DESCRIPTION
## Summary
- skip malformed ORF headers in `process_orf_fasta`
- add regression test for incomplete headers

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c812a77208322a4fcfcf16231693d