### PR TITLE
Fix BLASTP query name handling

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -39,11 +39,16 @@ from .module1_RM import download_if_needed, _fix_getorf_headers
 
 
 def _fix_blast_query_names(path: Path) -> None:
-    """Replace underscores with commas in BLAST output query names."""
+    """Normalize BLAST query names to comma-separated format.
 
-    pattern = re.compile(
-        r"^([^_]+)_([^_]+)_([0-9]+)_([0-9]+)_([+-])_([0-9]+)_([0-9]+)_([0-9]+)$"
-    )
+    BLAST replaces commas in sequence identifiers with underscores.  Previous
+    versions of this function used a strict regular expression which failed for
+    scaffold names containing underscores (e.g. ``186_phaseblock_2``).  The
+    implementation now parses identifiers more permissively by splitting from the
+    right to recover the numeric fields and only converting the first underscore
+    between ``name`` and ``scaf`` to a comma.  Other underscores are preserved.
+    """
+
     tmp = path.with_suffix(path.suffix + ".tmp")
     with open(path) as inp, open(tmp, "w") as out:
         for line in inp:
@@ -51,13 +56,31 @@ def _fix_blast_query_names(path: Path) -> None:
                 out.write(line)
                 continue
             fields = line.rstrip().split()
-            if fields:
-                m = pattern.match(fields[0])
-                if m:
-                    fields[0] = ",".join(m.groups())
-                    out.write("\t".join(fields) + "\n")
+            for i, f in enumerate(fields):
+                if "," in f or "_" not in f:
                     continue
-            out.write(line)
+                parts = f.split("_")
+                if len(parts) < 8:
+                    continue
+                prefix = "_".join(parts[:-6])
+                numeric = parts[-6:]
+                if not (
+                    numeric[0].isdigit()
+                    and numeric[1].isdigit()
+                    and numeric[3].isdigit()
+                    and numeric[4].isdigit()
+                    and numeric[5].isdigit()
+                    and numeric[2] in {"+", "-", "."}
+                ):
+                    continue
+                if "_" in prefix:
+                    name, scaf = prefix.split("_", 1)
+                else:
+                    name = prefix
+                    scaf = ""
+                fixed = [name, scaf] if scaf else [name]
+                fields[i] = ",".join(fixed + numeric)
+            out.write("\t".join(fields) + "\n")
     os.replace(tmp, path)
 
 from .find_longest_orf import find_longest_orf


### PR DESCRIPTION
## Summary
- fix _fix_blast_query_names to correctly handle scaffold names containing underscores
- update tests (all pass)

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9203ba548322a2d3ff23c874776c