### PR TITLE
feat: add flexible TE selection to module1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 ## Overview
 
-- HapLongLINEr discovers and curates full-length (≥5 kb by default) young LINE-1 elements (L1HS, L1PA2, and potentially intact L1PA3) in haploid long-read assemblies.  
-- We will potentially extend this to other types of polymorphic transposable elements.
+- HapLongLINEr discovers and curates full-length (≥5 kb by default) young LINE-1 elements (L1HS, L1PA2, and potentially intact L1PA3) in haploid long-read assemblies.
+- Module 1 can also search for other transposable elements such as SVA, ALU, or HERVK, or any user-provided RepeatMasker names via the `--te` option.
 
 
 ## Installation
@@ -56,6 +56,7 @@ Input:
 - Haploid assembly FASTA
 - RepeatMasker BED or .out file (plain or gzipped)
 - Reference genome FASTA (local or remote, hs1/hg38)
+- Transposable element families to analyse (via `--te`, default `L1,L1PA3`)
 
 Command with test genome:
 ```bash
@@ -75,9 +76,12 @@ haplongliner rm \
   --out your_output_dir
 ```
 
+To search additional TE families, include the `--te` option. For example,
+`--te L1,SVA` searches for both L1 and SVA elements.
+
 Output:
-- haplongliner_rm.bed file with L1 info from your assembly and corresponding refence genome (hs1/hg38) coordinates and ORF status
-- haplongliner_rm.fa file containing all full length (>=5kb by default) L1HS, L1PA2, and intact L1PA3 sequences from the input assembly
+- haplongliner_rm.bed file with TE info from your assembly and corresponding reference genome (hs1/hg38) coordinates and ORF status
+- haplongliner_rm.fa file containing all full length (>=5kb by default) sequences for the selected TE families
 - Log file (when using `-g/--log`) that summarizes results of each step of the pipeline module
 
 ### Module 2: Based structural variation calls, no RepeatMasker pre-masking of whole assembly needed

--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -35,7 +35,7 @@ def main():
         Usage:   haplongliner <command> <arguments>
         Version: {__version__}
 
-        Command: rm        RepeatMasker-based L1 discovery
+        Command: rm        RepeatMasker-based TE discovery
                  sv        SV-based L1 discovery
                  db        L1 sequence repository
         """
@@ -80,7 +80,7 @@ def main():
         usage=argparse.SUPPRESS,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Usage:   haplongliner rm [options]",
-        help="Module 1: RepeatMasker-based L1 discovery",
+        help="Module 1: RepeatMasker-based TE discovery",
     )
     parser_rm._positionals.title = ""
     parser_rm._optionals.title = "Options"
@@ -93,7 +93,19 @@ def main():
         dest="length",
         type=int,
         default=5000,
-        help="Minimum L1 length (default: 5000)",
+        help="Minimum TE length (default: 5000)",
+    )
+
+    parser_rm.add_argument(
+        "-t",
+        "--te",
+        dest="te",
+        default="L1,L1PA3",
+        help=(
+            "Comma-separated TE families to search. Shortcuts: "
+            "L1=L1HS,L1PA2; SVA=SVA_E,SVA_F; ALU=AluY; "
+            "HERVK=HERVK-int,LTR5_Hs (default: L1,L1PA3)"
+        ),
     )
 
     parser_rm.add_argument(
@@ -113,7 +125,7 @@ def main():
     )
 
     parser_rm.add_argument(
-        "-t",
+        "-v",
         "--liftover",
         dest="liftover",
         choices=["full", "flank"],
@@ -276,6 +288,7 @@ def main():
             min_length=args.length,
             asm=args.asm,
             liftover=args.liftover,
+            te=args.te,
         )
     elif args.command == "sv":
         # Determine reference path/URL for generating flanks when needed

--- a/haplongliner/extract_l1.py
+++ b/haplongliner/extract_l1.py
@@ -1,10 +1,50 @@
-"""Utility to extract full-length L1 records from a BED file."""
+"""Utility to extract full-length transposable element records from a BED file."""
 
 import sys
+from collections.abc import Iterable
 
 
-def extract_l1_from_bed(infile: str, outfile: str | None = None, min_length: int = 5000) -> None:
-    """Write BED records for L1s at least ``min_length`` bp long."""
+def _expand_te_names(te_list: Iterable[str]) -> set[str]:
+    """Return the set of RepeatMasker names for the requested TEs.
+
+    ``te_list`` contains user supplied identifiers such as ``"L1"`` or
+    ``"SVA"``.  The mapping is as follows::
+
+        L1    -> {"L1HS", "L1PA2"}
+        SVA   -> {"SVA_E", "SVA_F"}
+        ALU   -> {"AluY"}
+        HERVK -> {"HERVK-int", "LTR5_Hs"}
+
+    Any other value is used as-is, allowing custom TE names.
+    """
+
+    mapping = {
+        "L1": {"L1HS", "L1PA2"},
+        "SVA": {"SVA_E", "SVA_F"},
+        "ALU": {"AluY"},
+        "HERVK": {"HERVK-int", "LTR5_Hs"},
+    }
+    expanded: set[str] = set()
+    for te in te_list:
+        te_up = te.upper()
+        expanded.update(mapping.get(te_up, {te}))
+    return expanded
+
+
+def extract_te_from_bed(
+    infile: str,
+    outfile: str | None = None,
+    min_length: int = 5000,
+    te: str | Iterable[str] = ("L1", "L1PA3"),
+) -> None:
+    """Write BED records for selected TEs at least ``min_length`` bp long."""
+
+    if isinstance(te, str):
+        te_list = [t for t in te.split(",") if t]
+    else:
+        te_list = list(te)
+    allowed = _expand_te_names(te_list)
+
     out = open(outfile, "w") if outfile else sys.stdout
     with open(infile) as f:
         for line in f:
@@ -16,17 +56,27 @@ def extract_l1_from_bed(infile: str, outfile: str | None = None, min_length: int
             name = fields[3]
             start = int(fields[1])
             end = int(fields[2])
-            if name.startswith("L1") and (end - start) >= min_length:
+            if name in allowed and (end - start) >= min_length:
                 print(line, end="", file=out)
     if outfile:
         out.close()
+
+
+# Backward compatible alias
+def extract_l1_from_bed(
+    infile: str,
+    outfile: str | None = None,
+    min_length: int = 5000,
+    te: str | Iterable[str] = ("L1", "L1PA3"),
+) -> None:
+    extract_te_from_bed(infile, outfile, min_length, te)
 
 
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Extract full-length L1s from BED file."
+        description="Extract full-length TEs from BED file.",
     )
     parser.add_argument("infile", help="Input BED file")
     parser.add_argument("-o", "--outfile", help="Output file (default: stdout)")
@@ -35,7 +85,18 @@ if __name__ == "__main__":
         "--length",
         type=int,
         default=5000,
-        help="Minimum L1 length to keep (default: 5000)",
+        help="Minimum length to keep (default: 5000)",
+    )
+    parser.add_argument(
+        "-t",
+        "--te",
+        default="L1,L1PA3",
+        help=(
+            "Comma-separated list of TE families. Shortcuts: "
+            "L1=L1HS,L1PA2; SVA=SVA_E,SVA_F; ALU=AluY; "
+            "HERVK=HERVK-int,LTR5_Hs"
+        ),
     )
     args = parser.parse_args()
-    extract_l1_from_bed(args.infile, args.outfile, args.length)
+    extract_te_from_bed(args.infile, args.outfile, args.length, args.te)
+

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -254,17 +254,20 @@ def run_module1(
     min_length: int = 5000,
     asm: int = 10,
     liftover: str = "full",
+    te: str = "L1,L1PA3",
 ):
     """
-    RepeatMasker-based L1 discovery pipeline.
+    RepeatMasker-based TE discovery pipeline.
     Downloads remote reference if needed.
     Handles RepeatMasker BED, BED.gz, .out, or .out.gz input.
     ``log`` specifies a file to log malformed RepeatMasker lines. If not
     provided, the ``HAPLOGLINER_LOG`` environment variable is checked.
-    ``min_length`` controls the minimum L1 length to retain (default 5000 bp).
+    ``min_length`` controls the minimum TE length to retain (default 5000 bp).
     ``asm`` sets the minimap2 assembly preset (5, 10, or 20; default 10).
     ``liftover`` chooses between 'full' (whole-genome liftover) and 'flank'
     (2kb flanking sequence liftover). Default is 'full'.
+    ``te`` is a comma-separated list of TE families to search for.  Shortcuts:
+    ``L1``=L1HS/L1PA2, ``SVA``=SVA_E/SVA_F, ``ALU``=AluY, ``HERVK``=HERVK-int/LTR5_Hs.
     """
     if log is None:
         log = os.getenv("HAPLOGLINER_LOG")
@@ -292,6 +295,7 @@ def run_module1(
         f"  RepeatMasker: {repeatmasker_file}\n"
         f"  Reference: {reference_fasta}\n"
         f"  Output Dir: {outdir}\n"
+        f"  TE types: {te} (min length {min_length})\n"
         f"  ASM preset: asm{asm}"
     )
 
@@ -302,7 +306,7 @@ def run_module1(
     parsed_bed = outdir / "parsed_repeatmasker.bed"
     parse_repeatmasker(repeatmasker_file, parsed_bed, log)
 
-    # Extract full-length L1s from parsed BED
+    # Extract full-length TEs from parsed BED
     candidate_bed = outdir / "cand.bed"
     run_quiet(
         [
@@ -314,11 +318,13 @@ def run_module1(
             str(candidate_bed),
             "-l",
             str(min_length),
+            "-t",
+            te,
         ],
         check=True,
     )
 
-    # Extract the sequence of the full-length L1s using pyfaidx
+    # Extract the sequence of the full-length TEs using pyfaidx
     candidate_fa = outdir / "cand.fa"
     fa = Fasta(str(input_fasta))
     _extract_fasta(fa, candidate_bed, candidate_fa)
@@ -462,7 +468,10 @@ def run_module1(
     _write_rm_sequences(Path(input_fasta), candidate_bed, rm_fa)
 
     # Final output table
-    print(f"Module 1 completed. Results in {combined_out} and {rm_fa}")
+    print(
+        f"Module 1 completed. Detected {te} elements ≥{min_length} bp. "
+        f"Results in {combined_out} and {rm_fa}"
+    )
 
     # Remove large intermediate files to save space
     # for tmp in [


### PR DESCRIPTION
## Summary
- allow module 1 to scan selectable TE families using `--te`
- rename liftover flag to `-v/--liftover`
- document TE support in README

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689133738edc8322b9ef9b62aff27f5c