### PR TITLE
Fix liftover filtering when no minimum length given

### DIFF
--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -233,12 +233,12 @@ def _combine_full_liftover(
             if start_ref != "NA" and end_ref != "NA":
                 try:
                     rl = int(end_ref) - int(start_ref)
-                    if rl <= 2 * min_length:
+                    if min_length == 0 or rl <= 2 * min_length:
                         ref_len = str(rl)
                     else:
-                        chr_ref, start_ref, end_ref = "NA", "NA", "NA"
+                        chr_ref, start_ref, end_ref, ref_len = "NA", "NA", "NA", "NA"
                 except ValueError:
-                    chr_ref, start_ref, end_ref = "NA", "NA", "NA"
+                    chr_ref, start_ref, end_ref, ref_len = "NA", "NA", "NA", "NA"
 
             scaffold_info = f"{chrom},{start},{end},{length},{strand},RPM"
             out.write(

--- a/tests/test_combine_full_liftover.py
+++ b/tests/test_combine_full_liftover.py
@@ -13,3 +13,17 @@ def test_combine_full_liftover(tmp_path):
     fields = out.read_text().strip().split("\t")
     assert fields[0:7] == ["chr1", "1000", "1100", "L1HS", "100", "+", "intact"]
     assert fields[7] == "scaf1,100,200,100,+,RPM"
+
+
+def test_combine_full_liftover_minlen_zero(tmp_path):
+    lifted = tmp_path / "lifted.bed"
+    lifted.write_text("chr1\t1000\t1100\tscaf1,100,200,+,L1HS\t0\t+\n")
+    intact = tmp_path / "intact.blastp"
+    intact.write_text("scaf1,100,200,+\n")
+    cand = tmp_path / "cand.bed"
+    cand.write_text("scaf1\t100\t200\tL1HS\t100\t+\n")
+    out = tmp_path / "out.bed"
+    _combine_full_liftover(lifted, intact, cand, out, min_length=0)
+    fields = out.read_text().strip().split("\t")
+    assert fields[0:7] == ["chr1", "1000", "1100", "L1HS", "100", "+", "intact"]
+    assert fields[7] == "scaf1,100,200,100,+,RPM"


### PR DESCRIPTION
## Summary
- avoid dropping liftover coordinates when `min_length` is 0
- add regression test covering `min_length=0`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892615de2c88322acbbb749ab92e3f4