### PR TITLE
Skip ORF detection unless L1 length threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - HapLongLINEr discovers and curates full-length (≥5 kb by default) young LINE-1 elements (L1HS, L1PA2, and potentially intact L1PA3) in haploid long-read assemblies.
 - Module 1 can also search for other transposable elements such as SVA, ALU, or HERVK, or any user-provided RepeatMasker names via the `--te` option.
+- Intact ORF detection and the associated BLASTP and ORF sequence extraction steps run only when `--length` is at least 5000 and the `--te` option includes L1HS, L1PA2, or L1PA3; otherwise these steps are skipped.
 
 
 ## Installation
@@ -79,6 +80,8 @@ haplongliner rm \
 To search additional TE families, include the `--te` option. For example,
 `--te L1,SVA` searches for both L1 and SVA elements.
 
+Intact ORF detection is performed only when `--length` is at least 5000 and the `--te` list includes L1HS, L1PA2, or L1PA3; otherwise these ORF-related BLASTP and sequence extraction steps are skipped.
+
 Output:
 - haplongliner_rm.bed file with TE info from your assembly and corresponding reference genome (hs1/hg38) coordinates and ORF status
 - haplongliner_rm.fa file containing all full length (>=5kb by default) sequences for the selected TE families
@@ -111,6 +114,8 @@ haplongliner sv \
   --ref you_choose_hs1_or_hg38 \
   --out your_output_dir
 ```
+
+ORF validation is carried out only when `--length` is at least 5000; otherwise the BLASTP and ORF sequence extraction steps are skipped.
 
 Output:
 - haplongliner_sv.bed file summarizing L1 coordinates and ORF status. Names from insertion calls that do not overlap lifted L1s end with `;nr`.

--- a/haplongliner/module1_RM.py
+++ b/haplongliner/module1_RM.py
@@ -12,6 +12,7 @@ from pyfaidx import Fasta
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
 from .combine_table import combine_table, _read_intact
+from .extract_l1 import _expand_te_names
 from .utils import (
     verify_blast_db,
     run_quiet,
@@ -289,6 +290,13 @@ def run_module1(
         ref_local = data_dir / Path(reference_fasta).name
         reference_fasta = download_if_needed(reference_fasta, ref_local)
 
+    te_list = [t for t in te.split(",") if t]
+    expanded_te = _expand_te_names(te_list)
+    perform_orf = (
+        min_length >= 5000
+        and bool(expanded_te & {"L1HS", "L1PA2", "L1PA3"})
+    )
+
     print(
         "Module 1 running with:\n"
         f"  Input: {input_fasta}\n"
@@ -298,6 +306,11 @@ def run_module1(
         f"  TE types: {te} (min length {min_length})\n"
         f"  ASM preset: asm{asm}"
     )
+    if not perform_orf:
+        print(
+            "[INFO] Skipping intact ORF detection and associated BLASTP/sequence extraction steps "
+            "(requires --length ≥5000 and --te including L1HS/L1PA2/L1PA3)"
+        )
 
     print()
 
@@ -324,10 +337,11 @@ def run_module1(
         check=True,
     )
 
-    # Extract the sequence of the full-length TEs using pyfaidx
-    candidate_fa = outdir / "cand.fa"
+    # Extract the sequence of the full-length TEs using pyfaidx when ORF detection is enabled
     fa = Fasta(str(input_fasta))
-    _extract_fasta(fa, candidate_bed, candidate_fa)
+    candidate_fa = outdir / "cand.fa"
+    if perform_orf:
+        _extract_fasta(fa, candidate_bed, candidate_fa)
 
     if liftover == "2kb":
         print("\n[STEP 2] Performing liftover based on 2kb flanking sequences")
@@ -398,49 +412,57 @@ def run_module1(
                 stdout=out,
             )
 
-    print("\n[STEP 3] Detecting intact ORFs")
-    # 7-8. Detect ORFs and identify intact ones
-    # Detect ORFs and choose the longest ORF1/ORF2 per locus
-    orf_fa = outdir / "cand_orf.fa"
-    run_quiet(
-        [
-            "getorf",
-            "-sequence",
-            str(candidate_fa),
-            "-find",
-            "1",
-            "-outseq",
-            str(orf_fa),
-        ],
-        check=True,
-    )
-    _fix_getorf_headers(orf_fa, candidate_fa)
-    blastp_out = outdir / "cand_orf.blastp"
-    db_prefix = Path("data") / "L1rpORF12p.fa"
-    verify_blast_db(db_prefix)
-    run_quiet(
-        [
-            "blastp",
-            "-db",
-            str(db_prefix),
-            "-query",
-            str(orf_fa),
-            "-outfmt",
-            "6 std qlen slen sacc",
-            "-out",
-            str(blastp_out),
-        ],
-        check=True,
-    )
-    _fix_blast_query_names(blastp_out)
-    longest_orf_out = outdir / "cand_orf_combine.blastp"
-    find_longest_orf(blastp_out, longest_orf_out)
-    _fix_blast_query_names(longest_orf_out)
+    if perform_orf:
+        print("\n[STEP 3] Detecting intact ORFs")
+        # 7-8. Detect ORFs and identify intact ones
+        # Detect ORFs and choose the longest ORF1/ORF2 per locus
+        orf_fa = outdir / "cand_orf.fa"
+        run_quiet(
+            [
+                "getorf",
+                "-sequence",
+                str(candidate_fa),
+                "-find",
+                "1",
+                "-outseq",
+                str(orf_fa),
+            ],
+            check=True,
+        )
+        _fix_getorf_headers(orf_fa, candidate_fa)
+        blastp_out = outdir / "cand_orf.blastp"
+        db_prefix = Path("data") / "L1rpORF12p.fa"
+        verify_blast_db(db_prefix)
+        run_quiet(
+            [
+                "blastp",
+                "-db",
+                str(db_prefix),
+                "-query",
+                str(orf_fa),
+                "-outfmt",
+                "6 std qlen slen sacc",
+                "-out",
+                str(blastp_out),
+            ],
+            check=True,
+        )
+        _fix_blast_query_names(blastp_out)
+        longest_orf_out = outdir / "cand_orf_combine.blastp"
+        find_longest_orf(blastp_out, longest_orf_out)
+        _fix_blast_query_names(longest_orf_out)
 
-    # Identify intact ORFs
-    intact_out = outdir / "cand_orf_intact.blastp"
-    find_intact_orf(longest_orf_out, intact_out)
-    _fix_blast_query_names(intact_out)
+        # Identify intact ORFs
+        intact_out = outdir / "cand_orf_intact.blastp"
+        find_intact_orf(longest_orf_out, intact_out)
+        _fix_blast_query_names(intact_out)
+    else:
+        print(
+            "\n[STEP 3] Skipping intact ORF detection and BLASTP steps "
+            "(requires --length ≥5000 and --te including L1HS/L1PA2/L1PA3)"
+        )
+        intact_out = outdir / "cand_orf_intact.blastp"
+        intact_out.touch()
 
     print("\n[STEP 4] Preparing output files")
     # 9-10. Integrate ORF status, liftover information and write candidate sequences

--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -705,6 +705,13 @@ def run_module2(
         f"  ASM preset: asm{asm}"
     )
 
+    perform_orf = min_length >= 5000
+    if not perform_orf:
+        print(
+            "[INFO] Skipping intact ORF detection and associated BLASTP steps "
+            "(requires --length ≥5000)"
+        )
+
     print()
 
     outdir = Path(output_dir)
@@ -768,7 +775,7 @@ def run_module2(
 
     deletions, insertions = _parse_sv(Path(sv_file), Path(log) if log else None)
 
-    print("\n[STEP 5] Validating candidate L1s and their ORFs")
+    print("\n[STEP 5] Validating candidate L1s")
 
     status, ins_seqs = _classify_sv(lifted, deletions, insertions, outdir, lifted_reorg)
 
@@ -786,7 +793,14 @@ def run_module2(
         extra_ins,
     )
 
-    orf_present, intact_names = _validate_orfs(candidate_fa)
+    if perform_orf:
+        orf_present, intact_names = _validate_orfs(candidate_fa)
+    else:
+        print(
+            "[INFO] Skipping intact ORF detection and BLASTP steps "
+            "(requires --length ≥5000)"
+        )
+        orf_present, intact_names = set(), set()
     # cand.blastn determines presence status
     presence_names = _validate_presence(candidate_fa, min_length)
     # also mark sequences with >90% ORF coverage as present


### PR DESCRIPTION
## Summary
- avoid ORF detection, BLASTP and related sequence extraction unless `--length` ≥5000 and TE list contains L1HS/L1PA2/L1PA3
- document conditional ORF detection in README

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926afff3c083228c02c798a736a624