### PR TITLE
Handle HPRC reference BED without TE names in module2

### DIFF
--- a/haplongliner/module2_SV.py
+++ b/haplongliner/module2_SV.py
@@ -246,6 +246,52 @@ def _read_lifted_bed(path: Path) -> Dict[str, List[Tuple[str, int, int, str, Set
     return lifted
 
 
+def _filter_reference_bed(
+    raw_ref: Path, min_length: int, te: str, teref: str
+) -> Path:
+    """Filter reference BED records by TE family and length.
+
+    When ``teref`` is ``"hprc"`` the BED lacks TE family names in column 4.
+    In that case assume all entries are L1 elements and only apply the
+    length filter.
+    """
+
+    tmp = tempfile.NamedTemporaryFile("w", suffix=".bed", delete=False)
+    if teref == "hprc":
+        with open(raw_ref) as inp, open(tmp.name, "w") as out:
+            for line in inp:
+                if not line.strip() or line.startswith("#"):
+                    continue
+                fields = line.rstrip().split("\t")
+                if len(fields) < 3:
+                    continue
+                try:
+                    start = int(fields[1])
+                    end = int(fields[2])
+                except ValueError:
+                    continue
+                if (end - start) >= min_length:
+                    out.write(line if line.endswith("\n") else line + "\n")
+    else:
+        run_quiet(
+            [
+                sys.executable,
+                "-m",
+                "haplongliner.extract_l1",
+                str(raw_ref),
+                "-o",
+                tmp.name,
+                "-l",
+                str(min_length),
+                "-t",
+                te,
+            ],
+            check=True,
+        )
+    tmp.close()
+    return Path(tmp.name)
+
+
 def _create_lifted_reorg(
     lifted_bed: Path, ref_bed: Path, out_path: Path
 ) -> List[Tuple[str, int, int, str, int, str, str, str, int, int]]:
@@ -782,25 +828,7 @@ def run_module2(
             temp_files.append(raw_ref)
         else:
             raw_ref = Path(teref)
-
-    tmp = tempfile.NamedTemporaryFile("w", suffix=".bed", delete=False)
-    run_quiet(
-        [
-            sys.executable,
-            "-m",
-            "haplongliner.extract_l1",
-            str(raw_ref),
-            "-o",
-            tmp.name,
-            "-l",
-            str(min_length),
-            "-t",
-            te,
-        ],
-        check=True,
-    )
-    tmp.close()
-    ref_bed = Path(tmp.name)
+    ref_bed = _filter_reference_bed(raw_ref, min_length, te, teref)
     temp_files.append(ref_bed)
 
     ref_path = reference_fasta

--- a/tests/test_module2_reference_bed.py
+++ b/tests/test_module2_reference_bed.py
@@ -1,0 +1,23 @@
+from haplongliner.module2_SV import _filter_reference_bed
+
+
+def test_filter_reference_hprc(tmp_path):
+    raw = tmp_path / "hprc.bed"
+    raw.write_text(
+        "chr1\t0\t6000\tname1\t6000\t+\n" "chr1\t0\t4000\tname2\t4000\t+\n"
+    )
+    out = _filter_reference_bed(raw, 5000, "L1", "hprc")
+    lines = out.read_text().strip().splitlines()
+    assert len(lines) == 1
+    assert lines[0].split("\t")[3] == "name1"
+
+
+def test_filter_reference_nonhprc(tmp_path):
+    raw = tmp_path / "ref.bed"
+    raw.write_text(
+        "chr1\t0\t6000\tL1HS\t6000\t+\n" "chr1\t0\t6000\tSVA_E\t6000\t+\n"
+    )
+    out = _filter_reference_bed(raw, 5000, "L1", "hg38")
+    lines = out.read_text().strip().splitlines()
+    assert len(lines) == 1
+    assert lines[0].split("\t")[3] == "L1HS"


### PR DESCRIPTION
## Summary
- support HPRC reference beds lacking TE family names by assuming all entries are L1s
- add `_filter_reference_bed` helper and use it in `run_module2`
- test reference BED filtering for HPRC and non-HPRC sources

## Testing
- `pytest tests/test_module2_reference_bed.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b0fff65483228258c03dd51333c7