### PR TITLE
Skip BED filtering in SV mode for HPRC reference

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -823,8 +823,13 @@ def run_sv_mode(
             temp_files.append(raw_ref)
         else:
             raw_ref = Path(teref)
-    ref_bed = _filter_reference_bed(raw_ref, min_length, te, teref)
-    temp_files.append(ref_bed)
+    if teref == "hprc":
+        # The bundled HPRC reference is already restricted to L1 elements; retain
+        # all entries as-is and skip the length/TE-family filtering step.
+        ref_bed = raw_ref
+    else:
+        ref_bed = _filter_reference_bed(raw_ref, min_length, te, teref)
+        temp_files.append(ref_bed)
 
     ref_path = reference_fasta
     if ref_path.startswith("http://") or ref_path.startswith("https://"):


### PR DESCRIPTION
## Summary
- Skip `_filter_reference_bed` when `--teref hprc` is used in SV mode, leaving the bundled HPRC reference BED unfiltered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894fc8e63cc83228c3b042d0af7e49f