### PR TITLE
Remove liftover_paf wrapper and expose console entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 !/LICENSE
 !/setup.py
 !/pyproject.toml
-!/liftover_paf.py
 !/data/L1rp*
 !/data/HPRC_L1_hs_v2_v2fl.bed
 !/data/HPRC_L1_hs1_master_v2.bed

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ conda install haplongliner
 Run `haplongliner`, `haplongliner rm` (RM mode), `haplongliner sv` (SV mode) or
 `haplongliner seq` with no arguments to see the available options for each command.
 
+The PAF liftover helper is available as a separate console script:
+
+```bash
+liftover_paf --help
+# or
+python -m haplongliner.liftover_paf --help
+```
+
 ### RM mode: Based on RepeatMasker pre-masked genome assemblies
 
 Input:

--- a/haplongliner.egg-info/PKG-INFO
+++ b/haplongliner.egg-info/PKG-INFO
@@ -2,4 +2,7 @@ Metadata-Version: 2.4
 Name: haplongliner
 Version: 0.1.0
 License-File: LICENSE
+Requires-Dist: pyfaidx
+Requires-Dist: edlib
 Dynamic: license-file
+Dynamic: requires-dist

--- a/haplongliner.egg-info/SOURCES.txt
+++ b/haplongliner.egg-info/SOURCES.txt
@@ -2,7 +2,6 @@ LICENSE
 README.md
 pyproject.toml
 setup.py
-liftover_paf.py
 haplongliner/__init__.py
 haplongliner/cli.py
 haplongliner/combine_table.py
@@ -10,9 +9,9 @@ haplongliner/extract_l1.py
 haplongliner/find_intact_orf.py
 haplongliner/find_longest_orf.py
 haplongliner/liftover_paf.py
-haplongliner/sequence_retrieval_function.py
 haplongliner/process_orf.py
 haplongliner/rm_mode.py
+haplongliner/sequence_retrieval_function.py
 haplongliner/store_l1_diffs.py
 haplongliner/sv_mode.py
 haplongliner/utils.py
@@ -26,9 +25,9 @@ tests/test_combine_full_liftover.py
 tests/test_find_longest_orf.py
 tests/test_liftover.py
 tests/test_liftover_paf_strand.py
-tests/test_sequence_retrieval_function.py
 tests/test_process_orf.py
 tests/test_rm_fa.py
+tests/test_sequence_retrieval_function.py
 tests/test_sv.py
 tests/test_sv_collect.py
 tests/test_sv_extract.py

--- a/haplongliner.egg-info/entry_points.txt
+++ b/haplongliner.egg-info/entry_points.txt
@@ -1,2 +1,3 @@
 [console_scripts]
 haplongliner = haplongliner.cli:main
+liftover_paf = haplongliner.liftover_paf:main

--- a/haplongliner.egg-info/requires.txt
+++ b/haplongliner.egg-info/requires.txt
@@ -1,0 +1,2 @@
+pyfaidx
+edlib

--- a/liftover_paf.py
+++ b/liftover_paf.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-from haplongliner.liftover_paf import main
-
-if __name__ == "__main__":
-    raise SystemExit(main())
-

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "haplongliner=haplongliner.cli:main"
+            "haplongliner=haplongliner.cli:main",
+            "liftover_paf=haplongliner.liftover_paf:main",
         ]
     },
 )


### PR DESCRIPTION
## Summary
- drop duplicate `liftover_paf.py` script in repo root
- register `liftover_paf` as a console entry point and document how to invoke it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68950482c1cc83228ccd4e3640aa6215