### PR TITLE
feat: add summary statistics for pipeline steps

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -7,6 +7,7 @@ import shutil
 import os
 
 from pyfaidx import Fasta
+from collections import Counter
 
 from .find_longest_orf import find_longest_orf
 from .find_intact_orf import find_intact_orf
@@ -343,6 +344,24 @@ def run_rm_mode(
     if perform_orf:
         _extract_fasta(fa, candidate_bed, candidate_fa)
 
+    # Summary for Step 1
+    total_entries = 0
+    te_counts: Counter[str] = Counter()
+    with open(parsed_bed) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            total_entries += 1
+    with open(candidate_bed) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            te = line.split()[3]
+            te_counts[te] += 1
+    num_candidates = sum(te_counts.values())
+    te_summary = ", ".join(f"{k}:{v}" for k, v in te_counts.items()) if te_counts else "none"
+    print(f"[SUM] Parsed {total_entries} entries; {num_candidates} candidates after filtering ({te_summary})")
+
     if liftover == "flank2kb":
         print("\n[STEP 2] Performing liftover based on 2kb flanking sequences")
         # 4-6. Extract flanking 2kb regions, obtain their sequences and map them to the reference genome
@@ -381,6 +400,7 @@ def run_rm_mode(
             shell=True,
             check=True,
         )
+        print(f"[SUM] Generated flanking mappings for {num_candidates} candidates")
     else:
         print("\n[STEP 2] Performing liftover using whole-genome alignment")
         aln_paf = outdir / "genome_alignment.paf"
@@ -402,6 +422,8 @@ def run_rm_mode(
         import contextlib
         with open(lifted_bed, "w") as out, contextlib.redirect_stdout(out):
             liftover_paf(str(aln_paf), str(candidate_bed), 0, 0, 2.0, False)
+        lifted_count = sum(1 for line in open(lifted_bed) if line.strip())
+        print(f"[SUM] Lifted coordinates for {lifted_count} candidates")
 
     if perform_orf:
         print("\n[STEP 3] Detecting intact ORFs")
@@ -454,6 +476,10 @@ def run_rm_mode(
         )
         intact_out = outdir / "cand_orf_intact.blastp"
 
+    # Summary for Step 3
+    intact_records = _read_intact(intact_out)
+    print(f"[SUM] {len(intact_records)}/{num_candidates} candidates with intact ORFs")
+
     print("\n[STEP 4] Preparing output files")
     # 9-10. Integrate ORF status, liftover information and write candidate sequences
     # Integrate ORF status and liftover information
@@ -478,6 +504,24 @@ def run_rm_mode(
 
     rm_fa = outdir / "haplongliner_rm.fa"
     _write_rm_sequences(Path(input_fasta), candidate_bed, rm_fa)
+
+    # Summary for Step 4
+    total_final = 0
+    intact_final = 0
+    final_te_counts: Counter[str] = Counter()
+    with open(combined_out) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            total_final += 1
+            fields = line.strip().split()
+            final_te_counts[fields[3]] += 1
+            if len(fields) > 6 and fields[6] == "intact":
+                intact_final += 1
+    te_summary = ", ".join(f"{k}:{v}" for k, v in final_te_counts.items()) if final_te_counts else "none"
+    print(
+        f"[SUM] Final table contains {total_final} entries; {intact_final} intact ({te_summary})"
+    )
 
     # Final output table
     print(

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -6,6 +6,7 @@ import itertools
 import tempfile
 from pathlib import Path
 from typing import Dict, List, Tuple, Iterable, Set
+from collections import Counter
 
 from .utils import (
     run_quiet,
@@ -840,6 +841,20 @@ def run_sv_mode(
 
     verify_fasta_file(ref_path)
 
+    # Summary for Step 1
+    ref_total = 0
+    ref_te_counts: Counter[str] = Counter()
+    with open(ref_bed) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            ref_total += 1
+            fields = line.strip().split()
+            if len(fields) > 3:
+                ref_te_counts[fields[3]] += 1
+    te_summary = ", ".join(f"{k}:{v}" for k, v in ref_te_counts.items()) if ref_te_counts else "none"
+    print(f"[SUM] Prepared reference with {ref_total} entries ({te_summary})")
+
     print("\n[STEP 2] Mapping assemblies with minimap2")
 
     aln_paf = outdir / "genome_alignment.paf"
@@ -857,7 +872,9 @@ def run_sv_mode(
             check=True,
             stdout=out,
         )
-
+    with open(aln_paf) as fh:
+        alignments = sum(1 for _ in fh if _.strip())
+    print(f"[SUM] Generated {alignments} alignment records")
     print("\n[STEP 3] Lifting over candidate TE coordinates")
 
     lifted_bed = outdir / "lifted.bed"
@@ -868,10 +885,12 @@ def run_sv_mode(
 
     lifted_reorg = outdir / "lifted_reorg.bed"
     lifted = _create_lifted_reorg(lifted_bed, ref_bed, lifted_reorg)
+    print(f"[SUM] Lifted {len(lifted)} TE candidates")
 
     print("\n[STEP 4] Parsing structural variants")
 
     deletions, insertions = _parse_sv(Path(sv_file), Path(log) if log else None)
+    print(f"[SUM] Parsed {len(deletions)} deletions and {len(insertions)} insertions")
 
     print("\n[STEP 5] Validating candidate TEs")
 
@@ -915,6 +934,14 @@ def run_sv_mode(
         extra_ins,
         presence_names,
         intact_names,
+    )
+
+    # Summary for Step 5
+    status_counts = Counter(status.values())
+    status_summary = ", ".join(f"{k}:{v}" for k, v in status_counts.items()) if status_counts else "none"
+    print(
+        f"[SUM] Classified {len(status)} lifted TEs ({status_summary}); "
+        f"intact: {len(intact_names)}; extra insertions: {len(extra_ins)}"
     )
 
     print("\n[STEP 6] Writing output table")
@@ -978,6 +1005,25 @@ def run_sv_mode(
             out.write(
                 f"{chrom}\t{start}\t{end}\t{name_out}\t{target_len}\t.\t{final_stat}\t{target_info}\n"
             )
+    # Summary for Step 6
+    total_final = 0
+    final_status_counts: Counter[str] = Counter()
+    final_te_counts: Counter[str] = Counter()
+    with open(out_table) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            total_final += 1
+            fields = line.strip().split()
+            if len(fields) > 3:
+                final_te_counts[fields[3]] += 1
+            if len(fields) > 6:
+                final_status_counts[fields[6]] += 1
+    status_summary = ", ".join(f"{k}:{v}" for k, v in final_status_counts.items()) if final_status_counts else "none"
+    te_summary = ", ".join(f"{k}:{v}" for k, v in final_te_counts.items()) if final_te_counts else "none"
+    print(
+        f"[SUM] Final table has {total_final} entries; statuses: {status_summary}; TE counts: {te_summary}"
+    )
 
     print(f"SV mode completed. Results in {out_table} and {sv_fa}")
 


### PR DESCRIPTION
## Summary
- report candidate counts and TE breakdown at each step in rm_mode
- add per-step summaries for SV mode including reference prep, alignment, classification, and final table

## Testing
- `pip install pyfaidx`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950a9a70f08322a7641febc9aabdcb