### PR TITLE
Simplify summary logging

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -359,8 +359,10 @@ def run_rm_mode(
             te = line.split()[3]
             te_counts[te] += 1
     num_candidates = sum(te_counts.values())
-    te_summary = ", ".join(f"{k}:{v}" for k, v in te_counts.items()) if te_counts else "none"
-    print(f"[SUM] Parsed {total_entries} entries; {num_candidates} candidates after filtering ({te_summary})")
+    te_type_count = len(te_counts)
+    print(
+        f"[SUM] Parsed {total_entries} entries; {num_candidates} candidates after filtering across {te_type_count} TE types"
+    )
 
     if liftover == "flank2kb":
         print("\n[STEP 2] Performing liftover based on 2kb flanking sequences")
@@ -518,9 +520,9 @@ def run_rm_mode(
             final_te_counts[fields[3]] += 1
             if len(fields) > 6 and fields[6] == "intact":
                 intact_final += 1
-    te_summary = ", ".join(f"{k}:{v}" for k, v in final_te_counts.items()) if final_te_counts else "none"
+    te_type_count = len(final_te_counts)
     print(
-        f"[SUM] Final table contains {total_final} entries; {intact_final} intact ({te_summary})"
+        f"[SUM] Final table contains {total_final} entries; {intact_final} intact across {te_type_count} TE types"
     )
 
     # Final output table

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -852,8 +852,11 @@ def run_sv_mode(
             fields = line.strip().split()
             if len(fields) > 3:
                 ref_te_counts[fields[3]] += 1
-    te_summary = ", ".join(f"{k}:{v}" for k, v in ref_te_counts.items()) if ref_te_counts else "none"
-    print(f"[SUM] Prepared reference with {ref_total} entries ({te_summary})")
+    te_type_count = len(ref_te_counts)
+    msg = f"[SUM] Prepared reference with {ref_total} entries"
+    if te_type_count:
+        msg += f" across {te_type_count} TE types"
+    print(msg)
 
     print("\n[STEP 2] Mapping assemblies with minimap2")
 
@@ -938,9 +941,9 @@ def run_sv_mode(
 
     # Summary for Step 5
     status_counts = Counter(status.values())
-    status_summary = ", ".join(f"{k}:{v}" for k, v in status_counts.items()) if status_counts else "none"
+    num_statuses = len(status_counts)
     print(
-        f"[SUM] Classified {len(status)} lifted TEs ({status_summary}); "
+        f"[SUM] Classified {len(status)} lifted TEs across {num_statuses} status categories; "
         f"intact: {len(intact_names)}; extra insertions: {len(extra_ins)}"
     )
 
@@ -1019,10 +1022,10 @@ def run_sv_mode(
                 final_te_counts[fields[3]] += 1
             if len(fields) > 6:
                 final_status_counts[fields[6]] += 1
-    status_summary = ", ".join(f"{k}:{v}" for k, v in final_status_counts.items()) if final_status_counts else "none"
-    te_summary = ", ".join(f"{k}:{v}" for k, v in final_te_counts.items()) if final_te_counts else "none"
+    status_count = len(final_status_counts)
+    te_type_count = len(final_te_counts)
     print(
-        f"[SUM] Final table has {total_final} entries; statuses: {status_summary}; TE counts: {te_summary}"
+        f"[SUM] Final table has {total_final} entries across {status_count} status categories and {te_type_count} TE types"
     )
 
     print(f"SV mode completed. Results in {out_table} and {sv_fa}")


### PR DESCRIPTION
## Summary
- avoid listing every TE family in SV mode and RM mode summaries
- print only total counts and number of categories to prevent verbose console output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689519afc2248322a84f4b4199492ba5