### PR TITLE
Sort BED outputs in RM and SV modes

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -19,6 +19,7 @@ from .utils import (
     verify_fasta_file,
     verify_repeatmasker_file,
     _fix_blast_query_names,
+    sort_bed,
 )
 from .liftover_paf import liftover_paf
 
@@ -501,6 +502,8 @@ def run_rm_mode(
             combined_out,
             min_length=min_length,
         )
+
+    sort_bed(combined_out)
 
     rm_fa = outdir / "haplongliner_rm.fa"
     _write_rm_sequences(Path(input_fasta), candidate_bed, rm_fa)

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -16,6 +16,7 @@ from .utils import (
     verify_blast_db,
     read_paf,
     _fix_blast_query_names,
+    sort_bed,
 )
 from .liftover_paf import liftover_paf
 from pyfaidx import Fasta
@@ -1005,6 +1006,8 @@ def run_sv_mode(
             out.write(
                 f"{chrom}\t{start}\t{end}\t{name_out}\t{target_len}\t.\t{final_stat}\t{target_info}\n"
             )
+
+    sort_bed(out_table)
     # Summary for Step 6
     total_final = 0
     final_status_counts: Counter[str] = Counter()

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -99,6 +99,21 @@ def _fix_blast_query_names(path: Path) -> None:
     os.replace(tmp, path)
 
 
+def sort_bed(path: Path) -> None:
+    """Sort a BED-like file in-place by chromosome and start coordinate."""
+
+    with open(path) as fh:
+        lines = [l for l in fh if l.strip()]
+    header = [l for l in lines if l.startswith("#")]
+    data = [l for l in lines if not l.startswith("#")]
+    data_sorted = sorted(data, key=lambda l: (l.split()[0], int(l.split()[1])))
+    with open(path, "w") as out:
+        for line in header:
+            out.write(line)
+        for line in data_sorted:
+            out.write(line)
+
+
 def shift_fasta_start(fa_path: Path, delta: int = -1) -> None:
     """Adjust start coordinate in FASTA headers by ``delta``.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ from haplongliner.utils import (
     verify_repeatmasker_file,
     verify_sv_file,
     _fix_blast_query_names,
+    sort_bed,
 )
 
 
@@ -64,3 +65,17 @@ def test_fix_blast_query_names(tmp_path):
     assert fixed.startswith(
         "011138A1,186_phaseblock_2,1087928,1093929,+,6,876,1889\tsub"
     )
+
+
+def test_sort_bed(tmp_path):
+    path = tmp_path / "unsorted.bed"
+    path.write_text(
+        "chr2\t50\t60\nchr1\t30\t40\nchr1\t10\t20\n"
+    )
+    sort_bed(path)
+    assert path.read_text().splitlines() == [
+        "chr1\t10\t20",
+        "chr1\t30\t40",
+        "chr2\t50\t60",
+    ]
+


### PR DESCRIPTION
## Summary
- add `sort_bed` helper to order BED files by chromosome and start
- ensure RM and SV modes write sorted BED outputs
- cover sorting behavior with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951a3e862083228657b969ed6f7050