### PR TITLE
Handle non-integer starts in BED sorting

### DIFF
--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -106,7 +106,17 @@ def sort_bed(path: Path) -> None:
         lines = [l for l in fh if l.strip()]
     header = [l for l in lines if l.startswith("#")]
     data = [l for l in lines if not l.startswith("#")]
-    data_sorted = sorted(data, key=lambda l: (l.split()[0], int(l.split()[1])))
+
+    def _bed_key(line: str):
+        fields = line.split()
+        chrom = fields[0] if fields else ""
+        try:
+            start = int(fields[1])
+        except (IndexError, ValueError):
+            start = float("inf")
+        return chrom, start
+
+    data_sorted = sorted(data, key=_bed_key)
     with open(path, "w") as out:
         for line in header:
             out.write(line)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,3 +79,13 @@ def test_sort_bed(tmp_path):
         "chr2\t50\t60",
     ]
 
+
+def test_sort_bed_with_na_start(tmp_path):
+    path = tmp_path / "unsorted_na.bed"
+    path.write_text("chr1\tNA\t20\nchr1\t10\t20\n")
+    sort_bed(path)
+    assert path.read_text().splitlines() == [
+        "chr1\t10\t20",
+        "chr1\tNA\t20",
+    ]
+


### PR DESCRIPTION
## Summary
- Make `sort_bed` robust to non-numeric start coordinates
- Test handling of `NA` start positions when sorting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952b55b810832287572c2b6152b5b2