### PR TITLE
Ensure consistent info message formatting

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -87,7 +87,7 @@ def parse_repeatmasker(input_path, output_path, log_path=None):
     if log_path and skipped:
         with open(log_path, "w") as logf:
             logf.write("\n".join(skipped) + "\n")
-    print(f"Skipped {len(skipped)} malformed lines")
+    print(f"[INFO] Skipped {len(skipped)} malformed lines")
 
 
 def download_if_needed(url, local_path):
@@ -300,7 +300,7 @@ def run_rm_mode(
     )
 
     print(
-        "RM mode running with:\n"
+        "[INFO] RM mode running with:\n"
         f"  Input: {input_fasta}\n"
         f"  RepeatMasker: {repeatmasker_file}\n"
         f"  Reference: {reference_fasta}\n"
@@ -530,7 +530,7 @@ def run_rm_mode(
 
     # Final output table
     print(
-        f"RM mode completed. Detected {te} elements ≥{min_length} bp. "
+        f"[INFO] RM mode completed. Detected {te} elements ≥{min_length} bp. "
         f"Results in {combined_out} and {rm_fa}"
     )
 

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -779,7 +779,7 @@ def run_sv_mode(
     perform_orf = min_length >= 5000 and bool(expanded_te & {"L1HS", "L1PA2", "L1PA3"})
 
     print(
-        "SV mode running with:\n"
+        "[INFO] SV mode running with:\n"
         f"  Input: {input_fasta}\n"
         f"  SV: {sv_file}\n"
         f"  Reference: {reference_fasta}\n"
@@ -1031,7 +1031,7 @@ def run_sv_mode(
         f"[SUM] Final table has {total_final} entries across {status_count} status categories and {te_type_count} TE types"
     )
 
-    print(f"SV mode completed. Results in {out_table} and {sv_fa}")
+    print(f"[INFO] SV mode completed. Results in {out_table} and {sv_fa}")
 
     for tf in temp_files:
         try:


### PR DESCRIPTION
## Summary
- Prefix RM mode start, completion, and malformed-line logs with `[INFO]`
- Prefix SV mode start and completion logs with `[INFO]`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952b466be883228b3b4dec9b8bc32d