### PR TITLE
Ensure SV insertions undergo ORF/TE checks

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -538,14 +538,12 @@ def _extract_sequences(
                 out.write(f">{header}\n{seq}\n")
 
         for name, seq in ins_seqs.items():
-            if len(seq) >= min_length:
-                out.write(f">{name}_ins\n{seq}\n")
+            out.write(f">{name}_ins\n{seq}\n")
 
         if extra_ins:
             for chrom, start, end, seq, name in extra_ins:
-                if len(seq) >= min_length:
-                    header = f"{name},{chrom},{start},{end},."
-                    out.write(f">{header}\n{seq}\n")
+                header = f"{name},{chrom},{start},{end},."
+                out.write(f">{header}\n{seq}\n")
 
 
 def _write_sv_sequences(
@@ -902,7 +900,7 @@ def run_sv_mode(
     status, ins_seqs = _classify_sv(lifted, deletions, insertions, outdir, lifted_reorg)
 
     inter_ins = outdir / "intersect_ins.bed"
-    extra_ins = _collect_long_insertions(insertions, inter_ins, min_length)
+    extra_ins = _collect_long_insertions(insertions, inter_ins, 0)
 
     candidate_fa = outdir / "cand.fa"
     _extract_sequences(

--- a/tests/test_sv_extract.py
+++ b/tests/test_sv_extract.py
@@ -26,3 +26,16 @@ def test_extract_sequences_with_extras(tmp_path):
     _extract_sequences(fa, lifted, status, {}, out, 5, extras)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
     assert headers == [">INS_chr1_50,chr1,50,70,."]
+
+
+def test_extract_sequences_insertions_unfiltered(tmp_path):
+    fa = tmp_path / "test.fa"
+    fa.write_text(">chr1\n" + "A" * 100 + "\n")
+    lifted: list = []
+    status = {}
+    ins = {"L1a": "T" * 10}
+    extras = [("chr1", 80, 82, "G" * 2, "INS_chr1_80")]
+    out = tmp_path / "ins.fa"
+    _extract_sequences(fa, lifted, status, ins, out, 50, extras)
+    lines = [l.strip() for l in open(out)]
+    assert lines == [">L1a_ins", "T" * 10, ">INS_chr1_80,chr1,80,82,.", "G" * 2]


### PR DESCRIPTION
## Summary
- Always include SV insertions in cand.fa so they can be screened for ORFs and TE type
- Added regression test ensuring insertions are recorded even when below length threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895591671d48322b633d9c78adb0e59