### PR TITLE
Ensure blastn dependency is checked

### DIFF
--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -6,8 +6,17 @@ from typing import Dict, List
 
 
 def check_dependencies():
-    """Ensure required external tools are available."""
-    tools = ["minimap2", "getorf", "blastp"]
+    """Ensure required external tools are available.
+
+    ``blastn`` is used during structural-variant processing to validate
+    candidate LINE-1 sequences, but it was previously omitted from the
+    dependency check.  This meant users would only encounter a cryptic
+    subprocess failure later in the pipeline if ``blastn`` was missing from
+    the ``PATH``.  Including it here allows us to fail fast with a clear
+    message describing the missing requirement.
+    """
+
+    tools = ["minimap2", "getorf", "blastp", "blastn"]
     missing = [tool for tool in tools if shutil.which(tool) is None]
     if missing:
         sys.exit(

--- a/tests/test_check_dependencies.py
+++ b/tests/test_check_dependencies.py
@@ -1,0 +1,14 @@
+import pytest
+import haplongliner.utils as utils
+
+
+def test_reports_missing_blastn(monkeypatch):
+    def fake_which(tool):
+        return None if tool == "blastn" else "/usr/bin/" + tool
+
+    monkeypatch.setattr(utils.shutil, "which", fake_which)
+
+    with pytest.raises(SystemExit) as excinfo:
+        utils.check_dependencies()
+
+    assert "blastn" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- verify blastn is present alongside other required external tools
- add regression test to ensure missing blastn triggers a helpful error message

## Testing
- `pytest tests/test_check_dependencies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689565326c908322a185591bf89a4752