### PR TITLE
feat: replace blastn with repeatmasker for TE classification

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -732,49 +732,28 @@ def _remove_empty_sequences(fasta_path: Path) -> None:
 
 
 def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
-    """Return names of sequences aligning at least ``min_length`` bp to L1rp."""
+    """Return names of sequences classified as L1 with coverage ≥ ``min_length`` bp."""
     present: Set[str] = set()
     _remove_empty_sequences(candidate_fa)
     if candidate_fa.stat().st_size == 0:
         return present
 
-    blastn_out = candidate_fa.with_suffix(".blastn")
-    ref_fa = Path("data") / "L1rp.fa"
     run_quiet(
         [
-            "blastn",
-            "-query",
+            "RepeatMasker",
+            "-e",
+            "rmblast",
             str(candidate_fa),
-            "-subject",
-            str(ref_fa),
-            "-outfmt",
-            "6 std qlen slen",
-            "-out",
-            str(blastn_out),
         ],
         check=True,
     )
 
-    longest: Dict[str, int] = {}
-    with open(blastn_out) as fh:
-        for line in fh:
-            if not line.strip():
-                continue
-            f = line.strip().split()
-            if len(f) < 14:
-                continue
-            name = ",".join(f[0].split(",")[:3])
-            try:
-                length = int(f[3])
-            except ValueError:
-                continue
-            prev = longest.get(name, 0)
-            if length > prev:
-                longest[name] = length
-
-    for name, aln_len in longest.items():
-        if aln_len >= min_length:
-            present.add(name)
+    rm_out = candidate_fa.with_suffix(candidate_fa.suffix + ".out")
+    ref_fa = Path("data") / "L1rp.fa"
+    with open(ref_fa) as fh:
+        l1_len = sum(len(line.strip()) for line in fh if not line.startswith(">"))
+    cov_thresh = min_length / l1_len if l1_len else 1.0
+    present = _parse_repeatmasker(rm_out, l1_len, cov_thresh)
 
     return present
 
@@ -995,10 +974,10 @@ def run_sv_mode(
             scaf, *_rest, t_strand = plus_info.split(",")
             target_len = t_end - t_start
 
-            # Presence is determined solely by cand.blastn and
+            # Presence is determined solely by cand.fa.out and
             # cand_orf_intact.blastp results. Any sequence found in
             # cand_orf_intact.blastp is labeled "intact"; those only in
-            # cand.blastn are labeled "present". Everything else is
+            # cand.fa.out are labeled "present". Everything else is
             # considered "absent".
             key = f"{name},{scaf},{t_start}"
 

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -8,15 +8,12 @@ from typing import Dict, List
 def check_dependencies():
     """Ensure required external tools are available.
 
-    ``blastn`` is used during structural-variant processing to validate
-    candidate LINE-1 sequences, but it was previously omitted from the
-    dependency check.  This meant users would only encounter a cryptic
-    subprocess failure later in the pipeline if ``blastn`` was missing from
-    the ``PATH``.  Including it here allows us to fail fast with a clear
-    message describing the missing requirement.
+    ``RepeatMasker`` is used during structural-variant processing to classify
+    candidate LINE-1 sequences.  Including it in the dependency check allows
+    us to fail fast with a clear message if it is missing from the ``PATH``.
     """
 
-    tools = ["minimap2", "getorf", "blastp", "blastn"]
+    tools = ["minimap2", "getorf", "blastp", "RepeatMasker"]
     missing = [tool for tool in tools if shutil.which(tool) is None]
     if missing:
         sys.exit(

--- a/tests/test_check_dependencies.py
+++ b/tests/test_check_dependencies.py
@@ -2,13 +2,13 @@ import pytest
 import haplongliner.utils as utils
 
 
-def test_reports_missing_blastn(monkeypatch):
+def test_reports_missing_repeatmasker(monkeypatch):
     def fake_which(tool):
-        return None if tool == "blastn" else "/usr/bin/" + tool
+        return None if tool == "RepeatMasker" else "/usr/bin/" + tool
 
     monkeypatch.setattr(utils.shutil, "which", fake_which)
 
     with pytest.raises(SystemExit) as excinfo:
         utils.check_dependencies()
 
-    assert "blastn" in str(excinfo.value)
+    assert "RepeatMasker" in str(excinfo.value)

--- a/tests/test_validate_presence.py
+++ b/tests/test_validate_presence.py
@@ -8,19 +8,19 @@ def test_empty_sequences_are_filtered(monkeypatch, tmp_path):
     cand.write_text(">a\nACGT\n>b\n>c\nTTTT\n")
 
     def fake_run_quiet(cmd, check=True):  # pragma: no cover - behavior verified via assertions
-        query = Path(cmd[2])
+        query = Path(cmd[-1])
         content = query.read_text()
         assert ">a" in content
         assert ">c" in content
         assert ">b" not in content
-        out_path = Path(cmd[8])
+        out_path = query.with_suffix(query.suffix + ".out")
         out_path.write_text("")
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
     assert _validate_presence(cand, min_length=0) == set()
 
 
-def test_all_empty_sequences_skip_blast(monkeypatch, tmp_path):
+def test_all_empty_sequences_skip_repeatmasker(monkeypatch, tmp_path):
     cand = tmp_path / "cand.fa"
     cand.write_text(">a\n>b\n")
 


### PR DESCRIPTION
## Summary
- use RepeatMasker with rmblast engine to validate L1 presence in candidate sequences
- check RepeatMasker availability in dependency validator
- update tests for RepeatMasker-based workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979aa967d48322af8508746ff3c676