### PR TITLE
Handle insertion sequences in ORF validation

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -530,15 +530,14 @@ def _extract_sequences(
     with open(out_fa, "w") as out:
         for _, _, _, name, _, _, plus_info, _, t_start, t_end in lifted:
             scaf, _ps, _pe, t_strand = _parse_target_info(plus_info)
-            seq = fa[scaf][t_start:t_end].seq
-            if t_strand == "-":
-                seq = _revcomp(seq)
+            seq = ins_seqs.get(name)
+            if seq is None:
+                seq = fa[scaf][t_start:t_end].seq
+                if t_strand == "-":
+                    seq = _revcomp(seq)
             if seq:
                 header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
                 out.write(f">{header}\n{seq}\n")
-
-        for name, seq in ins_seqs.items():
-            out.write(f">{name}_ins\n{seq}\n")
 
         if extra_ins:
             for chrom, start, end, seq, name in extra_ins:
@@ -633,7 +632,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
     if candidate_fa.stat().st_size == 0:
         return present, intact
 
-    orf_fa = candidate_fa.with_name(candidate_fa.stem + "_.orf.fa")
+    orf_fa = candidate_fa.with_name(candidate_fa.stem + "_orf.fa")
     run_quiet(
         [
             "getorf",

--- a/tests/test_sv_extract.py
+++ b/tests/test_sv_extract.py
@@ -31,11 +31,13 @@ def test_extract_sequences_with_extras(tmp_path):
 def test_extract_sequences_insertions_unfiltered(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
-    lifted: list = []
-    status = {}
+    lifted = [
+        ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20)
+    ]
+    status = {"L1a": "present"}
     ins = {"L1a": "T" * 10}
     extras = [("chr1", 80, 82, "G" * 2, "INS_chr1_80")]
     out = tmp_path / "ins.fa"
     _extract_sequences(fa, lifted, status, ins, out, 50, extras)
     lines = [l.strip() for l in open(out)]
-    assert lines == [">L1a_ins", "T" * 10, ">INS_chr1_80,chr1,80,82,.", "G" * 2]
+    assert lines == [">L1a,chr1,10,20,+", "T" * 10, ">INS_chr1_80,chr1,80,82,.", "G" * 2]


### PR DESCRIPTION
## Summary
- Ensure candidate extraction substitutes insertion sequences directly and adds extras with consistent headers
- Rename SV-mode ORF output to `cand_orf.fa` for clarity
- Update tests for insertion sequence handling

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1609208988322a82a182a40958ec5