### PR TITLE
Include candidate sequences in ORF output

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -20,6 +20,7 @@ from .utils import (
     verify_repeatmasker_file,
     _fix_blast_query_names,
     sort_bed,
+    append_fasta,
 )
 from .liftover_paf import liftover_paf
 
@@ -474,6 +475,7 @@ def run_rm_mode(
         intact_out = outdir / "cand_orf_intact.blastp"
         find_intact_orf(longest_orf_out, intact_out)
         _fix_blast_query_names(intact_out)
+        append_fasta(orf_fa, candidate_fa)
     else:
         print(
             "\n[STEP 3] Skipping intact ORF detection and BLASTP steps "

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -17,6 +17,7 @@ from .utils import (
     read_paf,
     _fix_blast_query_names,
     sort_bed,
+    append_fasta,
 )
 from .liftover_paf import liftover_paf
 from pyfaidx import Fasta
@@ -699,6 +700,8 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
                 continue
             name = ",".join(fields[0].split(",")[:3])
             intact.add(name)
+
+    append_fasta(orf_fa, candidate_fa)
 
     return present, intact
 

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -105,6 +105,27 @@ def _fix_blast_query_names(path: Path) -> None:
     os.replace(tmp, path)
 
 
+def append_fasta(dst: Path, src: Path) -> None:
+    """Append FASTA records from ``src`` to ``dst``.
+
+    Ensures that the destination ends with a newline before appending and
+    silently skips missing or empty sources.
+    """
+
+    src_path = Path(src)
+    if not src_path.exists() or src_path.stat().st_size == 0:
+        return
+
+    dst_path = Path(dst)
+    with open(dst_path, "ab+") as out, open(src_path, "rb") as inp:
+        out.seek(0, os.SEEK_END)
+        if out.tell() > 0:
+            out.seek(-1, os.SEEK_END)
+            if out.read(1) != b"\n":
+                out.write(b"\n")
+        out.write(inp.read())
+
+
 def sort_bed(path: Path) -> None:
     """Sort a BED-like file in-place by chromosome and start coordinate."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from haplongliner.utils import (
     verify_sv_file,
     _fix_blast_query_names,
     sort_bed,
+    append_fasta,
 )
 
 
@@ -87,5 +88,19 @@ def test_sort_bed_with_na_start(tmp_path):
     assert path.read_text().splitlines() == [
         "chr1\t10\t20",
         "chr1\tNA\t20",
+    ]
+
+
+def test_append_fasta(tmp_path):
+    dst = tmp_path / "orf.fa"
+    dst.write_text(">a,1,2,+,1,1,2\nAA\n")
+    src = tmp_path / "cand.fa"
+    src.write_text(">a,1,2,+\nAAAA\n")
+    append_fasta(dst, src)
+    assert dst.read_text().splitlines() == [
+        ">a,1,2,+,1,1,2",
+        "AA",
+        ">a,1,2,+",
+        "AAAA",
     ]
 


### PR DESCRIPTION
## Summary
- add `append_fasta` utility for safe FASTA concatenation
- include original candidate sequences in `cand_orf.fa` for both RM and SV modes
- cover new helper with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a187498b3483228e31abf75e407313