### PR TITLE
Uppercase candidate sequences before ORF validation

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -537,11 +537,13 @@ def _extract_sequences(
                 if t_strand == "-":
                     seq = _revcomp(seq)
             if seq:
+                seq = seq.upper()
                 header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
                 out.write(f">{header}\n{seq}\n")
 
         if extra_ins:
             for chrom, start, end, seq, name in extra_ins:
+                seq = seq.upper()
                 header = f"{name},{chrom},{start},{end},."
                 out.write(f">{header}\n{seq}\n")
 


### PR DESCRIPTION
## Summary
- Uppercase candidate and extra insertion sequences when extracting candidates in `sv_mode` to ensure downstream ORF detection works for liftover-derived L1 sequences.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a25474a72c8322b8ab7ae5769c5a13