### PR TITLE
Run RepeatMasker in output directory for SV mode

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -750,6 +750,7 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
             str(candidate_fa),
         ],
         check=True,
+        cwd=candidate_fa.parent,
     )
 
     rm_out = candidate_fa.with_suffix(candidate_fa.suffix + ".out")

--- a/tests/test_validate_presence.py
+++ b/tests/test_validate_presence.py
@@ -7,7 +7,7 @@ def test_empty_sequences_are_filtered(monkeypatch, tmp_path):
     cand = tmp_path / "cand.fa"
     cand.write_text(">a\nACGT\n>b\n>c\nTTTT\n")
 
-    def fake_run_quiet(cmd, check=True):  # pragma: no cover - behavior verified via assertions
+    def fake_run_quiet(cmd, check=True, cwd=None):  # pragma: no cover - behavior verified via assertions
         query = Path(cmd[-1])
         content = query.read_text()
         assert ">a" in content
@@ -26,10 +26,24 @@ def test_all_empty_sequences_skip_repeatmasker(monkeypatch, tmp_path):
 
     called = {"flag": False}
 
-    def fake_run_quiet(cmd, check=True):  # pragma: no cover - should not be called
+    def fake_run_quiet(cmd, check=True, cwd=None):  # pragma: no cover - should not be called
         called["flag"] = True
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
     assert _validate_presence(cand, min_length=0) == set()
     assert not called["flag"]
+
+
+def test_repeatmasker_runs_in_output_dir(monkeypatch, tmp_path):
+    cand = tmp_path / "cand.fa"
+    cand.write_text(">a\nACGT\n")
+
+    def fake_run_quiet(cmd, check=True, cwd=None):
+        assert cwd == tmp_path
+        query = Path(cmd[-1])
+        out_path = query.with_suffix(query.suffix + ".out")
+        out_path.write_text("")
+
+    monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
+    assert _validate_presence(cand, min_length=0) == set()
 


### PR DESCRIPTION
## Summary
- ensure RepeatMasker in SV mode runs inside the output directory so RM temporary files are saved there
- add regression test confirming RepeatMasker uses the output directory

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2568b42b083228aea08a8f7077a23