### PR TITLE
Run BLAST after appending candidate sequences

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -650,6 +650,8 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
     )
     _fix_getorf_headers(orf_fa, candidate_fa)
 
+    append_fasta(orf_fa, candidate_fa)
+
     blastp_out = candidate_fa.with_name("cand_orf.blastp")
     db_prefix = Path("data") / "L1rpORF12p.fa"
     verify_blast_db(db_prefix)
@@ -702,9 +704,6 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
                 continue
             name = ",".join(fields[0].split(",")[:3])
             intact.add(name)
-
-    append_fasta(orf_fa, candidate_fa)
-
     return present, intact
 
 


### PR DESCRIPTION
## Summary
- ensure `_validate_orfs` runs BLAST on any sequences appended to `cand_orf.fa`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'haplongliner')*

------
https://chatgpt.com/codex/tasks/task_e_68a2b2aedee0832292be9628c23be82f