### PR TITLE
Handle empty cand_orf sequences before BLAST in SV mode

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -652,6 +652,10 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
 
     append_fasta(orf_fa, candidate_fa)
 
+    _remove_empty_sequences(orf_fa)
+    if orf_fa.stat().st_size == 0:
+        return present, intact
+
     blastp_out = candidate_fa.with_name("cand_orf.blastp")
     db_prefix = Path("data") / "L1rpORF12p.fa"
     verify_blast_db(db_prefix)


### PR DESCRIPTION
## Summary
- skip empty sequences in `cand_orf.fa` before running BLASTP in SV mode

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2e3411fc883228271b1585d93a977