### PR TITLE
Ensure SV cand_orf.fa stores ORF sequences

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -17,7 +17,6 @@ from .utils import (
     read_paf,
     _fix_blast_query_names,
     sort_bed,
-    append_fasta,
 )
 from .liftover_paf import liftover_paf
 from pyfaidx import Fasta
@@ -649,8 +648,6 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
         check=True,
     )
     _fix_getorf_headers(orf_fa, candidate_fa)
-
-    append_fasta(orf_fa, candidate_fa)
 
     _remove_empty_sequences(orf_fa)
     if orf_fa.stat().st_size == 0:

--- a/tests/test_sv_orf_fasta.py
+++ b/tests/test_sv_orf_fasta.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from haplongliner.sv_mode import _validate_orfs
+
+
+def test_validate_orfs_outputs_only_orfs(monkeypatch, tmp_path):
+    cand = tmp_path / "cand.fa"
+    cand.write_text(">L1,chr1,0,24,+\n" "ATGGCCATTGTAATGGGCCGCTGAA\n")
+
+    def fake_run_quiet(cmd, check=True, cwd=None):
+        # Simulate getorf and blastp calls by creating expected output files
+        if cmd[0] == "getorf":
+            out = Path(cmd[-1])
+            # Name is converted by getorf (commas -> underscores)
+            out.write_text(
+                ">L1_chr1_0_24_+_1 [1 - 24]\nMAIVMGR*\n"
+            )
+        elif cmd[0] == "blastp":
+            out = Path(cmd[-1])
+            out.write_text("")
+
+    monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
+    monkeypatch.setattr("haplongliner.sv_mode.verify_blast_db", lambda x: None)
+    monkeypatch.setattr("haplongliner.sv_mode.find_longest_orf", lambda inp, out: Path(out).write_text(""))
+    monkeypatch.setattr("haplongliner.sv_mode.find_intact_orf", lambda inp, out: Path(out).write_text(""))
+
+    _validate_orfs(cand)
+    orf_fa = cand.with_name("cand_orf.fa")
+    content = orf_fa.read_text()
+    assert ">L1,chr1,0,24,+\n" not in content
+    assert ">L1,chr1,0,24,+,1,1,24" in content


### PR DESCRIPTION
## Summary
- avoid appending nucleotide candidates to cand_orf.fa in SV mode so entries remain translated
- add regression test verifying cand_orf.fa contains only ORF sequences

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a63341a08322b136bf6c0e44d135