### PR TITLE
Include liftover ORFs in cand_orf.fa for SV mode

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -17,6 +17,7 @@ from .utils import (
     read_paf,
     _fix_blast_query_names,
     sort_bed,
+    append_fasta,
 )
 from .liftover_paf import liftover_paf
 from pyfaidx import Fasta
@@ -708,6 +709,50 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
     return present, intact
 
 
+def _append_liftover_orfs(orf_fa: Path, sv_fa: Path) -> None:
+    """Append ORFs from liftover-derived sequences in ``sv_fa`` to ``orf_fa``.
+
+    ``sv_fa`` contains sequences from the target assembly with headers formatted
+    as ``chrom,start,end,length,strand,stat`` where ``stat`` is ``INS`` for
+    insertion calls.  This function extracts ORFs from ``sv_fa`` using EMBOSS
+    ``getorf`` and appends ORFs for records whose ``stat`` is not ``INS`` to the
+    existing ``orf_fa`` file.
+    """
+
+    if not sv_fa.exists() or sv_fa.stat().st_size == 0:
+        return
+
+    liftover_orf = sv_fa.with_name("sv_orf.fa")
+    run_quiet(
+        [
+            "getorf",
+            "-sequence",
+            str(sv_fa),
+            "-find",
+            "1",
+            "-outseq",
+            str(liftover_orf),
+        ],
+        check=True,
+    )
+    _fix_getorf_headers(liftover_orf, sv_fa)
+
+    filtered = liftover_orf.with_suffix(".filtered")
+    with open(liftover_orf) as src, open(filtered, "w") as dst:
+        write = False
+        for line in src:
+            if line.startswith(">"):
+                fields = line[1:].strip().split(",")
+                write = len(fields) >= 6 and fields[5] != "INS"
+                if write:
+                    dst.write(line)
+            else:
+                if write:
+                    dst.write(line)
+
+    append_fasta(orf_fa, filtered)
+
+
 def _remove_empty_sequences(fasta_path: Path) -> None:
     """Remove records without sequence data from ``fasta_path`` in-place."""
     tmp_path = fasta_path.with_suffix(".tmp")
@@ -950,6 +995,9 @@ def run_sv_mode(
         presence_names,
         intact_names,
     )
+
+    if perform_orf:
+        _append_liftover_orfs(candidate_fa.with_name("cand_orf.fa"), sv_fa)
 
     # Summary for Step 5
     status_counts = Counter(status.values())

--- a/tests/test_sv_orf_fasta.py
+++ b/tests/test_sv_orf_fasta.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from haplongliner.sv_mode import _validate_orfs
+from haplongliner.sv_mode import _validate_orfs, _append_liftover_orfs
 
 
 def test_validate_orfs_outputs_only_orfs(monkeypatch, tmp_path):
@@ -29,3 +29,42 @@ def test_validate_orfs_outputs_only_orfs(monkeypatch, tmp_path):
     content = orf_fa.read_text()
     assert ">L1,chr1,0,24,+\n" not in content
     assert ">L1,chr1,0,24,+,1,1,24" in content
+
+
+def test_append_liftover_orfs(monkeypatch, tmp_path):
+    cand = tmp_path / "cand.fa"
+    cand.write_text(">INS_chr1_50,chr1,50,70,.\n" "ATGGCC\n")
+    sv_fa = tmp_path / "haplongliner_sv.fa"
+    sv_fa.write_text(
+        ">chr1,0,24,24,+,ALN\nATGGCCATTGTAATGGGCCGCTGAA\n"
+        ">chr1,50,70,20,+,INS\nATGGCC\n"
+    )
+
+    def fake_run_quiet(cmd, check=True, cwd=None):
+        out = Path(cmd[-1])
+        if cmd[0] == "getorf":
+            if out.name == "cand_orf.fa":
+                out.write_text(
+                    ">INS_chr1_50_chr1_50_70_._1 [1 - 6]\nMAIVMG\n"
+                )
+            else:
+                out.write_text(
+                    ">chr1_0_24_24_+_ALN_1 [1 - 24]\nMAIVMGR*\n"
+                    ">chr1_50_70_20_+_INS_1 [1 - 20]\nMAIVMGR*\n"
+                )
+        elif cmd[0] == "blastp":
+            out.write_text("")
+
+    monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
+    monkeypatch.setattr("haplongliner.sv_mode.verify_blast_db", lambda x: None)
+    monkeypatch.setattr("haplongliner.sv_mode.find_longest_orf", lambda inp, out: Path(out).write_text(""))
+    monkeypatch.setattr("haplongliner.sv_mode.find_intact_orf", lambda inp, out: Path(out).write_text(""))
+
+    _validate_orfs(cand)
+    orf_fa = cand.with_name("cand_orf.fa")
+    _append_liftover_orfs(orf_fa, sv_fa)
+
+    content = orf_fa.read_text()
+    assert ">INS_chr1_50,chr1,50,70,.,1,1,6" in content
+    assert ">chr1,0,24,24,+,ALN,1,1,24" in content
+    assert ">chr1,50,70,20,+,INS,1,1,20" not in content


### PR DESCRIPTION
## Summary
- append ORFs derived from liftover-based L1 sequences into SV mode's `cand_orf.fa`
- test that ORFs from liftover extractions are incorporated while insertion ORFs remain

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb3d234c8322bae35ab77fe03b53