### PR TITLE
Revise SV sequence extraction order

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -518,34 +518,31 @@ def _classify_sv(
 def _extract_sequences(
     fasta: Path,
     lifted: List[Tuple[str, int, int, str, int, str, str, str, int, int]],
-    status: Dict[str, str],
-    ins_seqs: Dict[str, str],
     out_fa: Path,
+    insertions: List[Tuple[str, int, int, str]],
     min_length: int,
-    extra_ins: List[Tuple[str, int, int, str, str]] | None = None,
 ) -> None:
-    """Extract candidate TE sequences from the target assembly."""
+    """Extract candidate TE and insertion sequences from the target assembly."""
 
     fa = Fasta(str(fasta))
 
     with open(out_fa, "w") as out:
         for _, _, _, name, _, _, plus_info, _, t_start, t_end in lifted:
             scaf, _ps, _pe, t_strand = _parse_target_info(plus_info)
-            seq = ins_seqs.get(name)
-            if seq is None:
-                seq = fa[scaf][t_start:t_end].seq
-                if t_strand == "-":
-                    seq = _revcomp(seq)
-            if seq:
-                seq = seq.upper()
-                header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
-                out.write(f">{header}\n{seq}\n")
+            seq = fa[scaf][t_start:t_end].seq
+            if t_strand == "-":
+                seq = _revcomp(seq)
+            seq = seq.upper()
+            header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
+            out.write(f">{header}\n{seq}\n")
 
-        if extra_ins:
-            for chrom, start, end, seq, name in extra_ins:
-                seq = seq.upper()
-                header = f"{name},{chrom},{start},{end},."
-                out.write(f">{header}\n{seq}\n")
+        for chrom, start, end, seq in insertions:
+            if len(seq) < min_length:
+                continue
+            seq = seq.upper()
+            name = f"INS_{chrom}_{start}"
+            header = f"{name},{chrom},{start},{end},."
+            out.write(f">{header}\n{seq}\n")
 
 
 def _write_sv_sequences(
@@ -958,17 +955,15 @@ def run_sv_mode(
     status, ins_seqs = _classify_sv(lifted, deletions, insertions, outdir, lifted_reorg)
 
     inter_ins = outdir / "intersect_ins.bed"
-    extra_ins = _collect_long_insertions(insertions, inter_ins, 0)
+    extra_ins = _collect_long_insertions(insertions, inter_ins, min_length)
 
     candidate_fa = outdir / "cand.fa"
     _extract_sequences(
         Path(input_fasta),
         lifted,
-        status,
-        ins_seqs,
         candidate_fa,
+        insertions,
         min_length,
-        extra_ins,
     )
 
     if perform_orf:

--- a/tests/test_sv_extract.py
+++ b/tests/test_sv_extract.py
@@ -9,35 +9,31 @@ def test_extract_sequences_names(tmp_path):
         ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
         ("chr1", 30, 40, "L1b", 10, "-", "chr1,30,40,-", "chr1,30,40,-", 30, 40),
     ]
-    status = {"L1a": "present", "L1b": "present"}
     out = tmp_path / "out.fa"
-    _extract_sequences(fa, lifted, status, {}, out, 5)
+    _extract_sequences(fa, lifted, out, [], 5)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
     assert headers == [">L1a,chr1,10,20,+", ">L1b,chr1,30,40,-"]
 
 
-def test_extract_sequences_with_extras(tmp_path):
+def test_extract_sequences_with_insertions(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted: list = []
-    status = {}
-    extras = [("chr1", 50, 70, "T" * 20, "INS_chr1_50")]
+    insertions = [("chr1", 50, 70, "T" * 20)]
     out = tmp_path / "extra.fa"
-    _extract_sequences(fa, lifted, status, {}, out, 5, extras)
+    _extract_sequences(fa, lifted, out, insertions, 5)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
     assert headers == [">INS_chr1_50,chr1,50,70,."]
 
 
-def test_extract_sequences_insertions_unfiltered(tmp_path):
+def test_extract_sequences_filters_short_insertions(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted = [
         ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20)
     ]
-    status = {"L1a": "present"}
-    ins = {"L1a": "T" * 10}
-    extras = [("chr1", 80, 82, "G" * 2, "INS_chr1_80")]
+    insertions = [("chr1", 80, 82, "G" * 2)]
     out = tmp_path / "ins.fa"
-    _extract_sequences(fa, lifted, status, ins, out, 50, extras)
+    _extract_sequences(fa, lifted, out, insertions, 50)
     lines = [l.strip() for l in open(out)]
-    assert lines == [">L1a,chr1,10,20,+", "T" * 10, ">INS_chr1_80,chr1,80,82,.", "G" * 2]
+    assert lines == [">L1a,chr1,10,20,+", "A" * 10]


### PR DESCRIPTION
## Summary
- Always extract lifted candidate sequences from the target genome
- Append SV insertion sequences exceeding the length cutoff after lifted sequences
- Update tests for new extraction behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a462990cd4832285e1626836c575c7