### PR TITLE
Filter empty ORFs before blastp

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -19,6 +19,7 @@ from .utils import (
     verify_fasta_file,
     verify_repeatmasker_file,
     _fix_blast_query_names,
+    read_nonempty_fasta,
     sort_bed,
     append_fasta,
 )
@@ -452,21 +453,27 @@ def run_rm_mode(
         blastp_out = outdir / "cand_orf.blastp"
         db_prefix = Path("data") / "L1rpORF12p.fa"
         verify_blast_db(db_prefix)
-        run_quiet(
-            [
-                "blastp",
-                "-db",
-                str(db_prefix),
-                "-query",
-                str(orf_fa),
-                "-outfmt",
-                "6 std qlen slen sacc",
-                "-out",
-                str(blastp_out),
-            ],
-            check=True,
-        )
-        _fix_blast_query_names(blastp_out)
+        filtered_fasta = read_nonempty_fasta(orf_fa)
+        if filtered_fasta:
+            run_quiet(
+                [
+                    "blastp",
+                    "-db",
+                    str(db_prefix),
+                    "-query",
+                    "-",
+                    "-outfmt",
+                    "6 std qlen slen sacc",
+                    "-out",
+                    str(blastp_out),
+                ],
+                input=filtered_fasta,
+                text=True,
+                check=True,
+            )
+            _fix_blast_query_names(blastp_out)
+        else:
+            blastp_out.touch()
         longest_orf_out = outdir / "cand_orf_combine.blastp"
         find_longest_orf(blastp_out, longest_orf_out)
         _fix_blast_query_names(longest_orf_out)

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -14,6 +14,7 @@ from .utils import (
     verify_sv_file,
     verify_repeatmasker_file,
     verify_blast_db,
+    read_nonempty_fasta,
     read_paf,
     _fix_blast_query_names,
     sort_bed,
@@ -647,9 +648,8 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
         check=True,
     )
     _fix_getorf_headers(orf_fa, candidate_fa)
-
-    _remove_empty_sequences(orf_fa)
-    if orf_fa.stat().st_size == 0:
+    filtered_fasta = read_nonempty_fasta(orf_fa)
+    if not filtered_fasta:
         return present, intact
 
     blastp_out = candidate_fa.with_name("cand_orf.blastp")
@@ -661,12 +661,14 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             "-db",
             str(db_prefix),
             "-query",
-            str(orf_fa),
+            "-",
             "-outfmt",
             "6 std qlen slen sacc",
             "-out",
             str(blastp_out),
         ],
+        input=filtered_fasta,
+        text=True,
         check=True,
     )
     _fix_blast_query_names(blastp_out)

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List
 
+from Bio import SeqIO
+
 
 def check_dependencies():
     """Ensure required external tools are available.
@@ -124,6 +126,16 @@ def append_fasta(dst: Path, src: Path) -> None:
             if out.read(1) != b"\n":
                 out.write(b"\n")
         out.write(inp.read())
+
+
+def read_nonempty_fasta(path: Path) -> str:
+    """Return FASTA text with only records containing sequence data."""
+
+    records = []
+    for record in SeqIO.parse(path, "fasta"):
+        if record.seq:
+            records.append(f">{record.description}\n{record.seq}\n")
+    return "".join(records)
 
 
 def sort_bed(path: Path) -> None:

--- a/tests/test_sv_orf_fasta.py
+++ b/tests/test_sv_orf_fasta.py
@@ -7,7 +7,7 @@ def test_validate_orfs_outputs_only_orfs(monkeypatch, tmp_path):
     cand = tmp_path / "cand.fa"
     cand.write_text(">L1,chr1,0,24,+\n" "ATGGCCATTGTAATGGGCCGCTGAA\n")
 
-    def fake_run_quiet(cmd, check=True, cwd=None):
+    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
         # Simulate getorf and blastp calls by creating expected output files
         if cmd[0] == "getorf":
             out = Path(cmd[-1])
@@ -40,7 +40,7 @@ def test_append_liftover_orfs(monkeypatch, tmp_path):
         ">chr1,50,70,20,+,INS\nATGGCC\n"
     )
 
-    def fake_run_quiet(cmd, check=True, cwd=None):
+    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
         out = Path(cmd[-1])
         if cmd[0] == "getorf":
             if out.name == "cand_orf.fa":

--- a/tests/test_validate_presence.py
+++ b/tests/test_validate_presence.py
@@ -7,7 +7,7 @@ def test_empty_sequences_are_filtered(monkeypatch, tmp_path):
     cand = tmp_path / "cand.fa"
     cand.write_text(">a\nACGT\n>b\n>c\nTTTT\n")
 
-    def fake_run_quiet(cmd, check=True, cwd=None):  # pragma: no cover - behavior verified via assertions
+    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):  # pragma: no cover - behavior verified via assertions
         query = Path(cmd[-1])
         content = query.read_text()
         assert ">a" in content
@@ -26,7 +26,7 @@ def test_all_empty_sequences_skip_repeatmasker(monkeypatch, tmp_path):
 
     called = {"flag": False}
 
-    def fake_run_quiet(cmd, check=True, cwd=None):  # pragma: no cover - should not be called
+    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):  # pragma: no cover - should not be called
         called["flag"] = True
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
@@ -38,7 +38,7 @@ def test_repeatmasker_runs_in_output_dir(monkeypatch, tmp_path):
     cand = tmp_path / "cand.fa"
     cand.write_text(">a\nACGT\n")
 
-    def fake_run_quiet(cmd, check=True, cwd=None):
+    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
         assert cwd == tmp_path
         query = Path(cmd[-1])
         out_path = query.with_suffix(query.suffix + ".out")


### PR DESCRIPTION
## Summary
- avoid modifying `cand_orf.fa` by filtering empty ORFs in memory before running blastp
- add utility to read non-empty FASTA records and reuse in rm and SV modes
- update tests for new `run_quiet` parameters

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48bee29d48322b4904a7796642c45