### PR TITLE
Filter short ORFs in RM and SV modes

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -22,6 +22,7 @@ from .utils import (
     read_nonempty_fasta,
     sort_bed,
     append_fasta,
+    filter_protein_fasta,
 )
 from .liftover_paf import liftover_paf
 
@@ -434,6 +435,7 @@ def run_rm_mode(
 
     if perform_orf:
         print("\n[STEP 3] Detecting intact ORFs")
+        print("[INFO] Retaining ORFs ≥270 aa (≥80% of L1 ORF1)")
         # 7-8. Detect ORFs and identify intact ones
         # Detect ORFs and choose the longest ORF1/ORF2 per locus
         orf_fa = outdir / "cand_orf.fa"
@@ -450,6 +452,7 @@ def run_rm_mode(
             check=True,
         )
         _fix_getorf_headers(orf_fa, candidate_fa)
+        filter_protein_fasta(orf_fa, 270)
         blastp_out = outdir / "cand_orf.blastp"
         db_prefix = Path("data") / "L1rpORF12p.fa"
         verify_blast_db(db_prefix)

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -19,6 +19,7 @@ from .utils import (
     _fix_blast_query_names,
     sort_bed,
     append_fasta,
+    filter_protein_fasta,
 )
 from .liftover_paf import liftover_paf
 from pyfaidx import Fasta
@@ -634,6 +635,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
         return present, intact
 
     # Generate ORFs in a file named ``cand_orf.fa`` to mirror RM mode
+    print("[INFO] Retaining ORFs ≥270 aa (≥80% of L1 ORF1)")
     orf_fa = candidate_fa.with_name("cand_orf.fa")
     run_quiet(
         [
@@ -648,6 +650,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
         check=True,
     )
     _fix_getorf_headers(orf_fa, candidate_fa)
+    filter_protein_fasta(orf_fa, 270)
     filtered_fasta = read_nonempty_fasta(orf_fa)
     if not filtered_fasta:
         return present, intact
@@ -749,7 +752,7 @@ def _append_liftover_orfs(orf_fa: Path, sv_fa: Path) -> None:
             else:
                 if write:
                     dst.write(line)
-
+    filter_protein_fasta(filtered, 270)
     append_fasta(orf_fa, filtered)
 
 

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -138,6 +138,17 @@ def read_nonempty_fasta(path: Path) -> str:
     return "".join(records)
 
 
+def filter_protein_fasta(path: Path, min_aa: int) -> None:
+    """Remove records shorter than ``min_aa`` amino acids from ``path``."""
+
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with open(path) as src, open(tmp_path, "w") as dst:
+        for record in SeqIO.parse(src, "fasta"):
+            if len(record.seq) >= min_aa:
+                SeqIO.write(record, dst, "fasta")
+    os.replace(tmp_path, path)
+
+
 def sort_bed(path: Path) -> None:
     """Sort a BED-like file in-place by chromosome and start coordinate."""
 

--- a/tests/test_sv_orf_fasta.py
+++ b/tests/test_sv_orf_fasta.py
@@ -5,66 +5,67 @@ from haplongliner.sv_mode import _validate_orfs, _append_liftover_orfs
 
 def test_validate_orfs_outputs_only_orfs(monkeypatch, tmp_path):
     cand = tmp_path / "cand.fa"
-    cand.write_text(">L1,chr1,0,24,+\n" "ATGGCCATTGTAATGGGCCGCTGAA\n")
+    cand.write_text(">L1,chr1,0,24,+\nATGGCCATTGTAATGGGCCGCTGAA\n")
 
     def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
-        # Simulate getorf and blastp calls by creating expected output files
         if cmd[0] == "getorf":
             out = Path(cmd[-1])
-            # Name is converted by getorf (commas -> underscores)
-            out.write_text(
-                ">L1_chr1_0_24_+_1 [1 - 24]\nMAIVMGR*\n"
-            )
+            out.write_text(">L1_chr1_0_24_+_1 [1 - 24]\nMAIVMGR*\n")
         elif cmd[0] == "blastp":
             out = Path(cmd[-1])
             out.write_text("")
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
     monkeypatch.setattr("haplongliner.sv_mode.verify_blast_db", lambda x: None)
-    monkeypatch.setattr("haplongliner.sv_mode.find_longest_orf", lambda inp, out: Path(out).write_text(""))
-    monkeypatch.setattr("haplongliner.sv_mode.find_intact_orf", lambda inp, out: Path(out).write_text(""))
+    monkeypatch.setattr(
+        "haplongliner.sv_mode.find_longest_orf", lambda inp, out: Path(out).write_text("")
+    )
+    monkeypatch.setattr(
+        "haplongliner.sv_mode.find_intact_orf", lambda inp, out: Path(out).write_text("")
+    )
 
     _validate_orfs(cand)
     orf_fa = cand.with_name("cand_orf.fa")
-    content = orf_fa.read_text()
-    assert ">L1,chr1,0,24,+\n" not in content
-    assert ">L1,chr1,0,24,+,1,1,24" in content
+    assert orf_fa.read_text() == ""
 
 
 def test_append_liftover_orfs(monkeypatch, tmp_path):
     cand = tmp_path / "cand.fa"
-    cand.write_text(">INS_chr1_50,chr1,50,70,.\n" "ATGGCC\n")
+    cand.write_text(">INS_chr1_50,chr1,50,70,.\nATGGCC\n")
     sv_fa = tmp_path / "haplongliner_sv.fa"
     sv_fa.write_text(
-        ">chr1,0,24,24,+,ALN\nATGGCCATTGTAATGGGCCGCTGAA\n"
-        ">chr1,50,70,20,+,INS\nATGGCC\n"
+        f">chr1,0,810,810,+,ALN\n{'ATG' * 270}\n"
+        f">chr1,50,830,780,+,INS\n{'ATG' * 270}\n"
     )
 
     def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
         out = Path(cmd[-1])
         if cmd[0] == "getorf":
             if out.name == "cand_orf.fa":
-                out.write_text(
-                    ">INS_chr1_50_chr1_50_70_._1 [1 - 6]\nMAIVMG\n"
-                )
+                out.write_text(">INS_chr1_50_chr1_50_70_._1 [1 - 6]\nMM\n")
             else:
+                prot = "M" * 270
                 out.write_text(
-                    ">chr1_0_24_24_+_ALN_1 [1 - 24]\nMAIVMGR*\n"
-                    ">chr1_50_70_20_+_INS_1 [1 - 20]\nMAIVMGR*\n"
+                    f">chr1_0_810_810_+_ALN_1 [1 - 810]\n{prot}\n"
+                    f">chr1_50_830_780_+_INS_1 [1 - 780]\n{prot}\n"
                 )
         elif cmd[0] == "blastp":
             out.write_text("")
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
     monkeypatch.setattr("haplongliner.sv_mode.verify_blast_db", lambda x: None)
-    monkeypatch.setattr("haplongliner.sv_mode.find_longest_orf", lambda inp, out: Path(out).write_text(""))
-    monkeypatch.setattr("haplongliner.sv_mode.find_intact_orf", lambda inp, out: Path(out).write_text(""))
+    monkeypatch.setattr(
+        "haplongliner.sv_mode.find_longest_orf", lambda inp, out: Path(out).write_text("")
+    )
+    monkeypatch.setattr(
+        "haplongliner.sv_mode.find_intact_orf", lambda inp, out: Path(out).write_text("")
+    )
 
     _validate_orfs(cand)
     orf_fa = cand.with_name("cand_orf.fa")
     _append_liftover_orfs(orf_fa, sv_fa)
 
     content = orf_fa.read_text()
-    assert ">INS_chr1_50,chr1,50,70,.,1,1,6" in content
-    assert ">chr1,0,24,24,+,ALN,1,1,24" in content
-    assert ">chr1,50,70,20,+,INS,1,1,20" not in content
+    assert ">INS_chr1_50,chr1,50,70,.,1,1,6" not in content
+    assert ">chr1,0,810,810,+,ALN,1,1,810" in content
+    assert ">chr1,50,830,780,+,INS,1,1,780" not in content


### PR DESCRIPTION
## Summary
- keep only ORFs ≥270 aa in `cand_orf.fa`
- announce 270aa (≈80% L1 ORF1) threshold in ORF detection messages
- ensure liftover-derived ORFs obey same minimum length

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6696e92cc83228a9e9d73be4be666