### PR TITLE
Filter short insertion sequences in SV mode

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -553,11 +553,17 @@ def _write_sv_sequences(
     status: Dict[str, str],
     ins_seqs: Dict[str, str],
     out_fa: Path,
+    min_length: int,
     extra_ins: List[Tuple[str, int, int, str, str]] | None = None,
     present: Set[str] | None = None,
     intact: Set[str] | None = None,
 ) -> None:
-    """Write sequences from the target assembly for ALN and INS entries."""
+    """Write sequences from the target assembly for ALN and INS entries.
+
+    Only insertion sequences with length >= ``min_length`` are written to
+    ``out_fa`` to avoid creating excessively large FASTA files for numerous
+    short insertions.
+    """
 
     fa = Fasta(str(fasta))
     if present is None:
@@ -600,7 +606,7 @@ def _write_sv_sequences(
                 out.write(f">{target_info}\n{seq}\n")
             elif sv_stat == "INS":
                 seq = ins_seqs.get(name, "")
-                if seq:
+                if len(seq) >= min_length:
                     out.write(f">{target_info}\n{seq}\n")
 
         for chrom, start, end, seq, name in extras:
@@ -992,6 +998,7 @@ def run_sv_mode(
         status,
         ins_seqs,
         sv_fa,
+        min_length,
         extra_ins,
         presence_names,
         intact_names,

--- a/tests/test_sv_fa.py
+++ b/tests/test_sv_fa.py
@@ -12,6 +12,6 @@ def test_write_sv_sequences(tmp_path):
     status = {"L1a": "present", "L1b": "present"}
     ins_seqs = {"L1b": "T" * 10}
     out = tmp_path / "sv.fa"
-    _write_sv_sequences(fa, lifted, status, ins_seqs, out)
+    _write_sv_sequences(fa, lifted, status, ins_seqs, out, 5)
     headers = [l.strip() for l in open(out) if l.startswith(">")]
     assert headers == [">chr1,10,20,10,+,ALN", ">chr1,30,40,10,+,INS"]

--- a/tests/test_sv_write.py
+++ b/tests/test_sv_write.py
@@ -1,0 +1,42 @@
+from haplongliner.sv_mode import _write_sv_sequences
+
+
+def _make_lifted_entry() -> list:
+    return [
+        (
+            "chr1",
+            0,
+            10,
+            "L1a",
+            10,
+            "+",
+            "chr1,0,10,+",
+            "chr1,0,10,+",
+            0,
+            10,
+        )
+    ]
+
+
+def test_write_sv_sequences_filters_short_insertions(tmp_path):
+    fa = tmp_path / "test.fa"
+    fa.write_text(">chr1\n" + "A" * 100 + "\n")
+    out = tmp_path / "sv.fa"
+    lifted = _make_lifted_entry()
+    status = {"L1a": "present"}
+    ins_seqs = {"L1a": "A" * 4}  # shorter than min_length
+    _write_sv_sequences(fa, lifted, status, ins_seqs, out, 5)
+    assert out.read_text() == ""
+
+
+def test_write_sv_sequences_writes_long_insertions(tmp_path):
+    fa = tmp_path / "test.fa"
+    fa.write_text(">chr1\n" + "A" * 100 + "\n")
+    out = tmp_path / "sv_long.fa"
+    lifted = _make_lifted_entry()
+    status = {"L1a": "present"}
+    ins_seqs = {"L1a": "T" * 6}
+    _write_sv_sequences(fa, lifted, status, ins_seqs, out, 5)
+    lines = [l.strip() for l in out.read_text().splitlines() if l.strip()]
+    assert lines == [">chr1,0,10,10,+,INS", "T" * 6]
+


### PR DESCRIPTION
## Summary
- Skip appending insertion sequences shorter than the user-specified length cutoff in SV mode
- Pass length threshold into SV sequence writer
- Add regression tests for filtering short insertions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a68cc83883228aaabdb4bc6f84f9