### PR TITLE
Use getorf minsize to filter ORFs

### DIFF
--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -22,7 +22,6 @@ from .utils import (
     read_nonempty_fasta,
     sort_bed,
     append_fasta,
-    filter_protein_fasta,
 )
 from .liftover_paf import liftover_paf
 
@@ -435,7 +434,7 @@ def run_rm_mode(
 
     if perform_orf:
         print("\n[STEP 3] Detecting intact ORFs")
-        print("[INFO] Retaining ORFs ≥270 aa (≥80% of L1 ORF1)")
+        print("[INFO] Using getorf -minsize 810 to retain ORFs ≥270 aa (≥80% of L1 ORF1)")
         # 7-8. Detect ORFs and identify intact ones
         # Detect ORFs and choose the longest ORF1/ORF2 per locus
         orf_fa = outdir / "cand_orf.fa"
@@ -448,11 +447,12 @@ def run_rm_mode(
                 "1",
                 "-outseq",
                 str(orf_fa),
+                "-minsize",
+                "810",
             ],
             check=True,
         )
         _fix_getorf_headers(orf_fa, candidate_fa)
-        filter_protein_fasta(orf_fa, 270)
         blastp_out = outdir / "cand_orf.blastp"
         db_prefix = Path("data") / "L1rpORF12p.fa"
         verify_blast_db(db_prefix)

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -19,7 +19,6 @@ from .utils import (
     _fix_blast_query_names,
     sort_bed,
     append_fasta,
-    filter_protein_fasta,
 )
 from .liftover_paf import liftover_paf
 from pyfaidx import Fasta
@@ -635,7 +634,7 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
         return present, intact
 
     # Generate ORFs in a file named ``cand_orf.fa`` to mirror RM mode
-    print("[INFO] Retaining ORFs ≥270 aa (≥80% of L1 ORF1)")
+    print("[INFO] Using getorf -minsize 810 to retain ORFs ≥270 aa (≥80% of L1 ORF1)")
     orf_fa = candidate_fa.with_name("cand_orf.fa")
     run_quiet(
         [
@@ -646,11 +645,12 @@ def _validate_orfs(candidate_fa: Path) -> Tuple[Set[str], Set[str]]:
             "1",
             "-outseq",
             str(orf_fa),
+            "-minsize",
+            "810",
         ],
         check=True,
     )
     _fix_getorf_headers(orf_fa, candidate_fa)
-    filter_protein_fasta(orf_fa, 270)
     filtered_fasta = read_nonempty_fasta(orf_fa)
     if not filtered_fasta:
         return present, intact
@@ -735,6 +735,8 @@ def _append_liftover_orfs(orf_fa: Path, sv_fa: Path) -> None:
             "1",
             "-outseq",
             str(liftover_orf),
+            "-minsize",
+            "810",
         ],
         check=True,
     )
@@ -752,7 +754,6 @@ def _append_liftover_orfs(orf_fa: Path, sv_fa: Path) -> None:
             else:
                 if write:
                     dst.write(line)
-    filter_protein_fasta(filtered, 270)
     append_fasta(orf_fa, filtered)
 
 

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -138,17 +138,6 @@ def read_nonempty_fasta(path: Path) -> str:
     return "".join(records)
 
 
-def filter_protein_fasta(path: Path, min_aa: int) -> None:
-    """Remove records shorter than ``min_aa`` amino acids from ``path``."""
-
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    with open(path) as src, open(tmp_path, "w") as dst:
-        for record in SeqIO.parse(src, "fasta"):
-            if len(record.seq) >= min_aa:
-                SeqIO.write(record, dst, "fasta")
-    os.replace(tmp_path, path)
-
-
 def sort_bed(path: Path) -> None:
     """Sort a BED-like file in-place by chromosome and start coordinate."""
 

--- a/tests/test_sv_orf_fasta.py
+++ b/tests/test_sv_orf_fasta.py
@@ -9,10 +9,10 @@ def test_validate_orfs_outputs_only_orfs(monkeypatch, tmp_path):
 
     def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
         if cmd[0] == "getorf":
-            out = Path(cmd[-1])
-            out.write_text(">L1_chr1_0_24_+_1 [1 - 24]\nMAIVMGR*\n")
+            out = Path(cmd[cmd.index("-outseq") + 1])
+            out.write_text("")
         elif cmd[0] == "blastp":
-            out = Path(cmd[-1])
+            out = Path(cmd[cmd.index("-out") + 1])
             out.write_text("")
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
@@ -39,10 +39,10 @@ def test_append_liftover_orfs(monkeypatch, tmp_path):
     )
 
     def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
-        out = Path(cmd[-1])
         if cmd[0] == "getorf":
+            out = Path(cmd[cmd.index("-outseq") + 1])
             if out.name == "cand_orf.fa":
-                out.write_text(">INS_chr1_50_chr1_50_70_._1 [1 - 6]\nMM\n")
+                out.write_text("")
             else:
                 prot = "M" * 270
                 out.write_text(
@@ -50,6 +50,7 @@ def test_append_liftover_orfs(monkeypatch, tmp_path):
                     f">chr1_50_830_780_+_INS_1 [1 - 780]\n{prot}\n"
                 )
         elif cmd[0] == "blastp":
+            out = Path(cmd[cmd.index("-out") + 1])
             out.write_text("")
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)


### PR DESCRIPTION
## Summary
- Filter ORFs directly during detection by invoking `getorf` with `-minsize 810`
- Remove post-processing ORF length filtering and update SV and RM pipelines
- Adjust tests for new ORF generation behavior

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a78e0d6483228a74b830e18a1e01