### PR TITLE
Add option to reuse genome alignment in SV mode

### DIFF
--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -217,6 +217,17 @@ def main():
         help="minimap2 asm preset (5, 10, or 20; default: 10)",
     )
     parser_sv.add_argument(
+        "-e",
+        "--exist",
+        dest="exist",
+        choices=["yes", "no"],
+        default="no",
+        help=(
+            "If 'yes', reuse genome_alignment.paf if present instead of remapping "
+            "with minimap2 (default: 'no')"
+        ),
+    )
+    parser_sv.add_argument(
         "-o",
         "--out",
         dest="output",
@@ -369,6 +380,7 @@ def main():
             min_length=args.length,
             asm=args.asm,
             xlength=args.xlength,
+            exist=args.exist,
         )
     elif args.command == "seq":
         run_sequence_retrieval_function(args.query, args.output, extra_fasta=args.extra)

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -836,6 +836,7 @@ def run_sv_mode(
     min_length: int = 0,
     asm: int = 10,
     xlength: int | None = None,
+    exist: str = "no",
 ) -> None:
     """RepeatMasker-free TE discovery using structural variants.
 
@@ -844,6 +845,8 @@ def run_sv_mode(
     ``te`` is a comma-separated list of TE families to search for.  Shortcuts
     follow :func:`haplongliner.extract_l1._expand_te_names` as in the RM mode.
     ``asm`` sets the minimap2 assembly preset (5, 10, or 20; default 10).
+    ``exist`` determines whether to reuse an existing ``genome_alignment.paf``
+    ("yes") or regenerate it ("no", default).
     """
 
     te_list = [t for t in te.split(",") if t]
@@ -938,20 +941,23 @@ def run_sv_mode(
     print("\n[STEP 2] Mapping assemblies with minimap2")
 
     aln_paf = outdir / "genome_alignment.paf"
-    with open(aln_paf, "w") as out:
-        run_quiet(
-            [
-                "minimap2",
-                "-x",
-                f"asm{asm}",
-                "-c",
-                "--cs",
-                str(input_fasta),
-                str(ref_path),
-            ],
-            check=True,
-            stdout=out,
-        )
+    if exist == "yes" and aln_paf.exists():
+        print("[INFO] Using existing genome_alignment.paf")
+    else:
+        with open(aln_paf, "w") as out:
+            run_quiet(
+                [
+                    "minimap2",
+                    "-x",
+                    f"asm{asm}",
+                    "-c",
+                    "--cs",
+                    str(input_fasta),
+                    str(ref_path),
+                ],
+                check=True,
+                stdout=out,
+            )
     with open(aln_paf) as fh:
         alignments = sum(1 for _ in fh if _.strip())
     print(f"[SUM] Generated {alignments} alignment records")

--- a/tests/test_sv.py
+++ b/tests/test_sv.py
@@ -1,7 +1,9 @@
 import gzip
 from pathlib import Path
 
-from haplongliner.sv_mode import _parse_sv
+import pytest
+
+from haplongliner.sv_mode import _parse_sv, run_sv_mode
 
 
 def test_parse_sv_handles_gz(tmp_path):
@@ -20,4 +22,34 @@ def test_parse_sv_handles_gz(tmp_path):
     del2, ins2 = _parse_sv(plain)
     assert del2 == deletions
     assert ins2 == insertions
+
+
+def test_reuse_existing_alignment(monkeypatch, tmp_path):
+    inp = tmp_path / "in.fa"
+    inp.write_text(">chr1\nACGT\n")
+    sv = tmp_path / "sv.bed"
+    sv.write_text("chr1\t0\t1\n")
+    ref = tmp_path / "ref.fa"
+    ref.write_text(">chr1\nACGT\n")
+
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    paf = outdir / "genome_alignment.paf"
+    paf.write_text("paf\n")
+
+    called = {"flag": False}
+
+    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):  # pragma: no cover - should not be called
+        called["flag"] = True
+
+    monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
+    def fake_liftover_paf(*args, **kwargs):  # pragma: no cover - stops execution
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr("haplongliner.sv_mode.liftover_paf", fake_liftover_paf)
+
+    with pytest.raises(RuntimeError, match="stop"):
+        run_sv_mode(str(inp), str(sv), str(ref), str(outdir), exist="yes")
+
+    assert not called["flag"]
 


### PR DESCRIPTION
## Summary
- add `--exist` CLI flag to reuse a precomputed `genome_alignment.paf`
- allow `run_sv_mode` to skip minimap2 and reuse existing alignments
- test that existing alignments skip minimap2 execution

## Testing
- `pip install biopython`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0aeb69cf88322bc010c07d53480bc