### PR TITLE
Split candidate sequences into liftover and insertion FASTAs

### DIFF
--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -188,7 +188,7 @@ def main():
         "--xlength",
         dest="xlength",
         type=int,
-        help="Maximum insertion length for cand.fa (default: max(20000, 3x --length))",
+        help="Maximum insertion length for cand_ins.fa (default: max(20000, 3x --length))",
     )
     parser_sv.add_argument(
         "-t",

--- a/haplongliner/rm_mode.py
+++ b/haplongliner/rm_mode.py
@@ -345,9 +345,15 @@ def run_rm_mode(
 
     # Extract the sequence of the full-length TEs using pyfaidx when ORF detection is enabled
     fa = Fasta(str(input_fasta))
+    candidate_lift_fa = outdir / "cand_lift.fa"
+    candidate_ins_fa = outdir / "cand_ins.fa"
     candidate_fa = outdir / "cand.fa"
     if perform_orf:
-        _extract_fasta(fa, candidate_bed, candidate_fa)
+        _extract_fasta(fa, candidate_bed, candidate_lift_fa)
+        candidate_ins_fa.write_text("")
+        candidate_fa.write_text("")
+        append_fasta(candidate_fa, candidate_lift_fa)
+        append_fasta(candidate_fa, candidate_ins_fa)
 
     # Summary for Step 1
     total_entries = 0

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -523,7 +523,8 @@ def _classify_sv(
 def _extract_sequences(
     fasta: Path,
     lifted: List[Tuple[str, int, int, str, int, str, str, str, int, int]],
-    out_fa: Path,
+    out_lift: Path,
+    out_ins: Path,
     insertions: List[Tuple[str, int, int, str]],
     min_length: int,
     max_length: int,
@@ -532,7 +533,7 @@ def _extract_sequences(
 
     fa = Fasta(str(fasta))
 
-    with open(out_fa, "w") as out:
+    with open(out_lift, "w") as lift:
         for _, _, _, name, _, _, plus_info, _, t_start, t_end in lifted:
             scaf, _ps, _pe, t_strand = _parse_target_info(plus_info)
             seq = fa[scaf][t_start:t_end].seq
@@ -540,15 +541,16 @@ def _extract_sequences(
                 seq = _revcomp(seq)
             seq = seq.upper()
             header = f"{name},{scaf},{t_start},{t_end},{t_strand}"
-            out.write(f">{header}\n{seq}\n")
+            lift.write(f">{header}\n{seq}\n")
 
+    with open(out_ins, "w") as ins:
         for chrom, start, end, seq in insertions:
             if len(seq) < min_length or len(seq) > max_length:
                 continue
             seq = seq.upper()
             name = f"INS_{chrom}_{start}"
             header = f"{name},{chrom},{start},{end},."
-            out.write(f">{header}\n{seq}\n")
+            ins.write(f">{header}\n{seq}\n")
 
 
 def _write_sv_sequences(
@@ -985,16 +987,22 @@ def run_sv_mode(
     inter_ins = outdir / "intersect_ins.bed"
     extra_ins = _collect_long_insertions(insertions, inter_ins, min_length, xlength)
 
-    candidate_fa = outdir / "cand.fa"
-    print(f"[INFO] Ignoring insertion sequences >{xlength} bp for cand.fa")
+    candidate_lift_fa = outdir / "cand_lift.fa"
+    candidate_ins_fa = outdir / "cand_ins.fa"
+    print(f"[INFO] Ignoring insertion sequences >{xlength} bp for cand_ins.fa")
     _extract_sequences(
         Path(input_fasta),
         lifted,
-        candidate_fa,
+        candidate_lift_fa,
+        candidate_ins_fa,
         insertions,
         min_length,
         xlength,
     )
+    candidate_fa = outdir / "cand.fa"
+    candidate_fa.write_text("")
+    append_fasta(candidate_fa, candidate_lift_fa)
+    append_fasta(candidate_fa, candidate_ins_fa)
 
     if perform_orf:
         orf_present, intact_names = _validate_orfs(candidate_fa)

--- a/tests/test_sv_extract.py
+++ b/tests/test_sv_extract.py
@@ -9,10 +9,12 @@ def test_extract_sequences_names(tmp_path):
         ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
         ("chr1", 30, 40, "L1b", 10, "-", "chr1,30,40,-", "chr1,30,40,-", 30, 40),
     ]
-    out = tmp_path / "out.fa"
-    _extract_sequences(fa, lifted, out, [], 5, 1000)
-    headers = [l.strip() for l in open(out) if l.startswith(">")]
+    out_lift = tmp_path / "lift.fa"
+    out_ins = tmp_path / "ins.fa"
+    _extract_sequences(fa, lifted, out_lift, out_ins, [], 5, 1000)
+    headers = [l.strip() for l in open(out_lift) if l.startswith(">")]
     assert headers == [">L1a,chr1,10,20,+", ">L1b,chr1,30,40,-"]
+    assert out_ins.read_text() == ""
 
 
 def test_extract_sequences_with_insertions(tmp_path):
@@ -20,10 +22,12 @@ def test_extract_sequences_with_insertions(tmp_path):
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted: list = []
     insertions = [("chr1", 50, 70, "T" * 20)]
-    out = tmp_path / "extra.fa"
-    _extract_sequences(fa, lifted, out, insertions, 5, 1000)
-    headers = [l.strip() for l in open(out) if l.startswith(">")]
+    out_lift = tmp_path / "lift.fa"
+    out_ins = tmp_path / "extra.fa"
+    _extract_sequences(fa, lifted, out_lift, out_ins, insertions, 5, 1000)
+    headers = [l.strip() for l in open(out_ins) if l.startswith(">")]
     assert headers == [">INS_chr1_50,chr1,50,70,."]
+    assert out_lift.read_text() == ""
 
 
 def test_extract_sequences_filters_short_insertions(tmp_path):
@@ -33,16 +37,20 @@ def test_extract_sequences_filters_short_insertions(tmp_path):
         ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20)
     ]
     insertions = [("chr1", 80, 82, "G" * 2)]
-    out = tmp_path / "ins.fa"
-    _extract_sequences(fa, lifted, out, insertions, 50, 1000)
-    lines = [l.strip() for l in open(out)]
+    out_lift = tmp_path / "lift.fa"
+    out_ins = tmp_path / "ins.fa"
+    _extract_sequences(fa, lifted, out_lift, out_ins, insertions, 50, 1000)
+    lines = [l.strip() for l in open(out_lift)]
     assert lines == [">L1a,chr1,10,20,+", "A" * 10]
+    assert out_ins.read_text() == ""
 
 
 def test_extract_sequences_filters_long_insertions(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     insertions = [("chr1", 50, 90, "T" * 40)]
-    out = tmp_path / "long.fa"
-    _extract_sequences(fa, [], out, insertions, 5, 30)
-    assert out.read_text() == ""
+    out_lift = tmp_path / "lift.fa"
+    out_ins = tmp_path / "long.fa"
+    _extract_sequences(fa, [], out_lift, out_ins, insertions, 5, 30)
+    assert out_lift.read_text() == ""
+    assert out_ins.read_text() == ""


### PR DESCRIPTION
## Summary
- Separate candidate extraction into `cand_lift.fa` for lifted LINE-1s and `cand_ins.fa` for insertions
- Combine both files for downstream ORF and presence validation
- Update CLI help text and tests accordingly

## Testing
- `pip install -e .`
- `pip install biopython`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b33250188322803f6f4534da1cac