### PR TITLE
Use unique liftover identifiers

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -221,7 +221,7 @@ def _write_bed(
 
 
 def _read_lifted_bed(path: Path) -> Dict[str, List[Tuple[str, int, int, str, Set[str]]]]:
-    """Return mapping ``name -> list of lifted coordinates`` from liftover_paf output."""
+    """Return mapping ``id -> list of lifted coordinates`` from liftover_paf output."""
 
     lifted: Dict[str, List[Tuple[str, int, int, str, Set[str]]]] = {}
     with open(path) as fh:
@@ -240,8 +240,9 @@ def _read_lifted_bed(path: Path) -> Dict[str, List[Tuple[str, int, int, str, Set
             parts = info.split(",")
             if len(parts) < 5:
                 continue
-            _qchrom, _qs, _qe, _qstrand, name, *tags = parts
-            lifted.setdefault(name, []).append((scaf, start, end, strand, set(tags)))
+            qchrom, qs, qe, _qstrand, _name, *tags = parts
+            key = f"{qchrom}:{qs}-{qe}"
+            lifted.setdefault(key, []).append((scaf, start, end, strand, set(tags)))
     return lifted
 
 
@@ -306,7 +307,7 @@ def _create_lifted_reorg(
             f = line.rstrip().split("\t")
             if len(f) < 6:
                 continue
-            chrom, start_s, end_s, name, length_s, strand = f[:6]
+            chrom, start_s, end_s, _name, length_s, strand = f[:6]
             try:
                 start = int(start_s)
                 end = int(end_s)
@@ -314,10 +315,11 @@ def _create_lifted_reorg(
             except ValueError:
                 continue
 
-            infos = mapping.get(name)
+            key = f"{chrom}:{start}-{end}"
+            infos = mapping.get(key)
             if not infos:
                 out.write(
-                    f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\tna\n"
+                    f"{chrom}\t{start}\t{end}\t{key}\t{length}\t{strand}\tna\n"
                 )
                 continue
 
@@ -335,7 +337,7 @@ def _create_lifted_reorg(
                         chrom,
                         start,
                         end,
-                        name,
+                        key,
                         length,
                         strand,
                         info,
@@ -347,7 +349,7 @@ def _create_lifted_reorg(
 
             info_joined = ";".join(info_strs)
             out.write(
-                f"{chrom}\t{start}\t{end}\t{name}\t{length}\t{strand}\t{info_joined}\n"
+                f"{chrom}\t{start}\t{end}\t{key}\t{length}\t{strand}\t{info_joined}\n"
             )
 
     return lifted

--- a/tests/test_sv_extract.py
+++ b/tests/test_sv_extract.py
@@ -6,14 +6,14 @@ def test_extract_sequences_names(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted = [
-        ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
-        ("chr1", 30, 40, "L1b", 10, "-", "chr1,30,40,-", "chr1,30,40,-", 30, 40),
+        ("chr1", 10, 20, "chr1:10-20", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
+        ("chr1", 30, 40, "chr1:30-40", 10, "-", "chr1,30,40,-", "chr1,30,40,-", 30, 40),
     ]
     out_lift = tmp_path / "lift.fa"
     out_ins = tmp_path / "ins.fa"
     _extract_sequences(fa, lifted, out_lift, out_ins, [], 5, 1000)
     headers = [l.strip() for l in open(out_lift) if l.startswith(">")]
-    assert headers == [">L1a,chr1,10,20,+", ">L1b,chr1,30,40,-"]
+    assert headers == [">chr1:10-20,chr1,10,20,+", ">chr1:30-40,chr1,30,40,-"]
     assert out_ins.read_text() == ""
 
 
@@ -34,14 +34,14 @@ def test_extract_sequences_filters_short_insertions(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted = [
-        ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20)
+        ("chr1", 10, 20, "chr1:10-20", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20)
     ]
     insertions = [("chr1", 80, 82, "G" * 2)]
     out_lift = tmp_path / "lift.fa"
     out_ins = tmp_path / "ins.fa"
     _extract_sequences(fa, lifted, out_lift, out_ins, insertions, 50, 1000)
     lines = [l.strip() for l in open(out_lift)]
-    assert lines == [">L1a,chr1,10,20,+", "A" * 10]
+    assert lines == [">chr1:10-20,chr1,10,20,+", "A" * 10]
     assert out_ins.read_text() == ""
 
 

--- a/tests/test_sv_fa.py
+++ b/tests/test_sv_fa.py
@@ -6,11 +6,11 @@ def test_write_sv_sequences(tmp_path):
     fa = tmp_path / "test.fa"
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     lifted = [
-        ("chr1", 10, 20, "L1a", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
-        ("chr1", 30, 40, "L1b", 10, "+", "chr1,30,40,+", "chr1,30,40,+", 30, 40),
+        ("chr1", 10, 20, "chr1:10-20", 10, "+", "chr1,10,20,+", "chr1,10,20,+", 10, 20),
+        ("chr1", 30, 40, "chr1:30-40", 10, "+", "chr1,30,40,+", "chr1,30,40,+", 30, 40),
     ]
-    status = {"L1a": "present", "L1b": "present"}
-    ins_seqs = {"L1b": "T" * 10}
+    status = {"chr1:10-20": "present", "chr1:30-40": "present"}
+    ins_seqs = {"chr1:30-40": "T" * 10}
     out = tmp_path / "sv.fa"
     _write_sv_sequences(fa, lifted, status, ins_seqs, out, 5, 1000)
     headers = [l.strip() for l in open(out) if l.startswith(">")]

--- a/tests/test_sv_write.py
+++ b/tests/test_sv_write.py
@@ -7,7 +7,7 @@ def _make_lifted_entry() -> list:
             "chr1",
             0,
             10,
-            "L1a",
+            "chr1:0-10",
             10,
             "+",
             "chr1,0,10,+",
@@ -23,8 +23,8 @@ def test_write_sv_sequences_filters_short_insertions(tmp_path):
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     out = tmp_path / "sv.fa"
     lifted = _make_lifted_entry()
-    status = {"L1a": "present"}
-    ins_seqs = {"L1a": "A" * 4}  # shorter than min_length
+    status = {"chr1:0-10": "present"}
+    ins_seqs = {"chr1:0-10": "A" * 4}  # shorter than min_length
     _write_sv_sequences(fa, lifted, status, ins_seqs, out, 5, 1000)
     assert out.read_text() == ""
 
@@ -34,8 +34,8 @@ def test_write_sv_sequences_writes_long_insertions(tmp_path):
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     out = tmp_path / "sv_long.fa"
     lifted = _make_lifted_entry()
-    status = {"L1a": "present"}
-    ins_seqs = {"L1a": "T" * 6}
+    status = {"chr1:0-10": "present"}
+    ins_seqs = {"chr1:0-10": "T" * 6}
     _write_sv_sequences(fa, lifted, status, ins_seqs, out, 5, 1000)
     lines = [l.strip() for l in out.read_text().splitlines() if l.strip()]
     assert lines == [">chr1,0,10,10,+,INS", "T" * 6]
@@ -46,8 +46,8 @@ def test_write_sv_sequences_filters_long_insertions(tmp_path):
     fa.write_text(">chr1\n" + "A" * 100 + "\n")
     out = tmp_path / "sv_long_filter.fa"
     lifted = _make_lifted_entry()
-    status = {"L1a": "present"}
-    ins_seqs = {"L1a": "T" * 40}
+    status = {"chr1:0-10": "present"}
+    ins_seqs = {"chr1:0-10": "T" * 40}
     _write_sv_sequences(fa, lifted, status, ins_seqs, out, 5, 30)
     assert out.read_text() == ""
 


### PR DESCRIPTION
## Summary
- Index liftover records by source coordinates instead of TE family names
- Generate `lifted_reorg.bed` entries using coordinate-based IDs and update downstream handling
- Adjust tests for new identifier format

## Testing
- `pip install -e .`
- `pip install biopython`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0bbb896bc8322a863d27a2b01f165