### PR TITLE
Handle RepeatMasker failures in candidate validation

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -4,6 +4,7 @@ import sys
 import gzip
 import itertools
 import tempfile
+import subprocess
 from pathlib import Path
 from typing import Dict, List, Tuple, Iterable, Set
 from collections import Counter
@@ -807,16 +808,22 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
     if candidate_fa.stat().st_size == 0:
         return present
 
-    run_quiet(
-        [
-            "RepeatMasker",
-            "-e",
-            "rmblast",
-            str(candidate_fa),
-        ],
-        check=True,
-        cwd=candidate_fa.parent,
-    )
+    try:
+        run_quiet(
+            [
+                "RepeatMasker",
+                "-e",
+                "rmblast",
+                str(candidate_fa),
+            ],
+            cwd=candidate_fa.parent,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "RepeatMasker failed while validating candidate sequences. "
+            "Ensure RepeatMasker and the rmblast engine are installed and "
+            "configured correctly."
+        ) from exc
 
     rm_out = candidate_fa.with_suffix(candidate_fa.suffix + ".out")
     ref_fa = Path("data") / "L1rp.fa"

--- a/tests/test_validate_presence.py
+++ b/tests/test_validate_presence.py
@@ -1,6 +1,10 @@
 from pathlib import Path
+import subprocess
+
+import pytest
 
 from haplongliner.sv_mode import _validate_presence
+import haplongliner.sv_mode as sv_mode
 
 
 def test_empty_sequences_are_filtered(monkeypatch, tmp_path):
@@ -47,3 +51,16 @@ def test_repeatmasker_runs_in_output_dir(monkeypatch, tmp_path):
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
     assert _validate_presence(cand, min_length=0) == set()
 
+def test_validate_presence_reports_repeatmasker_failure(tmp_path, monkeypatch):
+    fa = tmp_path / "cand.fa"
+    fa.write_text(">seq\nAAAA\n")
+
+    def fake_run_quiet(cmd, **kwargs):
+        raise subprocess.CalledProcessError(255, cmd)
+
+    monkeypatch.setattr(sv_mode, "run_quiet", fake_run_quiet)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sv_mode._validate_presence(fa)
+
+    assert "RepeatMasker" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- avoid crashing when RepeatMasker exits with an error during L1 candidate validation
- test _validate_presence behavior when RepeatMasker fails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0bdfb0268832286da946a67784625