### PR TITLE
Verify RepeatMasker Dfam data during dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ cd HapLongLINEr
 pip install -e .
 ```
 
+### Ensure RepeatMasker Dfam library
+
+HapLongLINEr requires RepeatMasker with the Dfam database.  The human repeat
+models reside in partition 7.  If this partition is missing, install it with:
+
+```bash
+cd $(dirname $(which RepeatMasker))/..
+python util/famdb.py --download current --partition 7
+perl configure
+```
+
+The `famdb.py` utility depends on the `h5py` Python package:
+
+```bash
+pip install h5py
+```
+
 ### Install as a conda package (to be implemented)
 
 Enable the required channels:

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -814,6 +814,10 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
                 "RepeatMasker",
                 "-e",
                 "rmblast",
+                "-species",
+                "human",
+                "-pa",
+                "4",
                 str(candidate_fa),
             ],
             cwd=candidate_fa.parent,
@@ -821,8 +825,8 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(
             "RepeatMasker failed while validating candidate sequences. "
-            "Ensure RepeatMasker and the rmblast engine are installed and "
-            "configured correctly."
+            "Ensure RepeatMasker, the rmblast engine, and the Dfam library "
+            "(partition 7 for human) are installed and configured correctly."
         ) from exc
 
     rm_out = candidate_fa.with_suffix(candidate_fa.suffix + ".out")

--- a/haplongliner/utils.py
+++ b/haplongliner/utils.py
@@ -7,13 +7,29 @@ from typing import Dict, List
 from Bio import SeqIO
 
 
-def check_dependencies():
-    """Ensure required external tools are available.
+def _verify_dfam_partition() -> None:
+    """Ensure the RepeatMasker Dfam partition for human is installed."""
 
-    ``RepeatMasker`` is used during structural-variant processing to classify
-    candidate LINE-1 sequences.  Including it in the dependency check allows
-    us to fail fast with a clear message if it is missing from the ``PATH``.
-    """
+    rm_bin = shutil.which("RepeatMasker")
+    if not rm_bin:  # pragma: no cover - handled by check_dependencies
+        return
+
+    rm_dir = Path(rm_bin).resolve().parent.parent
+    lib_dir = rm_dir / "Libraries"
+    if (lib_dir / "Dfam.h5").exists():
+        return
+
+    famdb_dir = lib_dir / "famdb"
+    if not famdb_dir.exists() or not any(p.name.endswith("_7.h5") for p in famdb_dir.glob("*.h5")):
+        sys.exit(
+            "Error: RepeatMasker Dfam partition for 'human' (7) is missing.\n"
+            f"Download it with:\n  cd {rm_dir}\n  python util/famdb.py --download current --partition 7\n  perl configure\n"
+            "(Requires the 'h5py' package: pip install h5py)"
+        )
+
+
+def check_dependencies():
+    """Ensure required external tools and libraries are available."""
 
     tools = ["minimap2", "getorf", "blastp", "RepeatMasker"]
     missing = [tool for tool in tools if shutil.which(tool) is None]
@@ -21,6 +37,13 @@ def check_dependencies():
         sys.exit(
             f"Error: The following required tools are missing from your PATH: {', '.join(missing)}"
         )
+
+    try:
+        import h5py  # noqa: F401
+    except ImportError:
+        sys.exit("Error: Python package 'h5py' is required. Install with 'pip install h5py'.")
+
+    _verify_dfam_partition()
 
 
 def verify_blast_db(db_prefix):

--- a/tests/test_check_dependencies.py
+++ b/tests/test_check_dependencies.py
@@ -1,3 +1,5 @@
+import builtins
+import sys
 import pytest
 import haplongliner.utils as utils
 
@@ -12,3 +14,39 @@ def test_reports_missing_repeatmasker(monkeypatch):
         utils.check_dependencies()
 
     assert "RepeatMasker" in str(excinfo.value)
+
+
+def test_reports_missing_h5py(monkeypatch):
+    monkeypatch.setattr(utils.shutil, "which", lambda tool: "/usr/bin/" + tool)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "h5py":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(SystemExit) as excinfo:
+        utils.check_dependencies()
+
+    assert "h5py" in str(excinfo.value)
+
+
+def test_reports_missing_dfam_partition(monkeypatch, tmp_path):
+    rm_dir = tmp_path / "RepeatMasker"
+    (rm_dir / "Libraries" / "famdb").mkdir(parents=True)
+    rm_bin = rm_dir / "RepeatMasker"
+    rm_bin.write_text("")
+
+    def fake_which(tool):
+        return str(rm_bin) if tool == "RepeatMasker" else "/usr/bin/" + tool
+
+    monkeypatch.setattr(utils.shutil, "which", fake_which)
+    monkeypatch.setitem(sys.modules, "h5py", object())
+
+    with pytest.raises(SystemExit) as excinfo:
+        utils.check_dependencies()
+
+    assert "partition 7" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- ensure Dfam partition 7 is installed and h5py is available in dependency checks
- run RepeatMasker with human species and 4 threads in SV mode
- document Dfam installation steps and add tests for h5py/partition detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b63d39b54083229d639a5f1604ac26