### PR TITLE
Fix RepeatMasker path handling for relative subdir FASTA

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -856,7 +856,7 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
                 "RepeatMasker",
                 "-e",
                 "rmblast",
-                str(short_fa),
+                short_fa.name,
             ],
             cwd=candidate_fa.parent,
         )
@@ -867,7 +867,7 @@ def _validate_presence(candidate_fa: Path, min_length: int = 5000) -> Set[str]:
             "configured correctly."
         ) from exc
 
-    short_out = short_fa.with_suffix(short_fa.suffix + ".out")
+    short_out = candidate_fa.parent / (short_fa.name + ".out")
     rm_out = candidate_fa.with_suffix(candidate_fa.suffix + ".out")
     _restore_rm_out_names(short_out, list_file, rm_out)
 

--- a/tests/test_validate_presence.py
+++ b/tests/test_validate_presence.py
@@ -12,7 +12,7 @@ def test_empty_sequences_are_filtered(monkeypatch, tmp_path):
     cand.write_text(">a\nACGT\n>b\n>c\nTTTT\n")
 
     def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):  # pragma: no cover - behavior verified via assertions
-        query = Path(cmd[-1])
+        query = Path(cwd) / cmd[-1]
         mapping = query.with_name("cand.list").read_text()
         assert "a" in mapping
         assert "c" in mapping
@@ -43,8 +43,8 @@ def test_repeatmasker_runs_in_output_dir(monkeypatch, tmp_path):
     cand.write_text(">a\nACGT\n")
 
     def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
-        assert cwd == tmp_path
-        query = Path(cmd[-1])
+        assert Path(cwd).resolve() == tmp_path
+        query = Path(cwd) / cmd[-1]
         out_path = query.with_suffix(query.suffix + ".out")
         out_path.write_text("")
 
@@ -64,3 +64,26 @@ def test_validate_presence_reports_repeatmasker_failure(tmp_path, monkeypatch):
         sv_mode._validate_presence(fa)
 
     assert "RepeatMasker" in str(excinfo.value)
+
+
+def test_validate_presence_relative_path_subdir(monkeypatch, tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    cand = sub / "cand.fa"
+    cand.write_text(">a\nACGT\n")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "L1rp.fa").write_text(">ref\nAAAA\n")
+
+    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):  # pragma: no cover - behavior validated via assertions
+        assert Path(cwd).resolve() == sub
+        assert cmd[-1] == "cand_short.fa"
+        query = Path(cwd) / cmd[-1]
+        out_path = query.with_suffix(query.suffix + ".out")
+        out_path.write_text("")
+
+    monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
+    monkeypatch.chdir(tmp_path)
+    assert _validate_presence(Path("sub") / "cand.fa", min_length=0) == set()
+    assert (sub / "cand.fa.out").exists()


### PR DESCRIPTION
## Summary
- ensure `_validate_presence` invokes RepeatMasker using just the FASTA filename and resolves the output path
- add regression test for validating a FASTA in a subdirectory via relative path

## Testing
- `python -m pytest tests/test_validate_presence.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72e5aa8688322a8b103073f3828bb