### PR TITLE
Allow TE family prefix matching

### DIFF
--- a/haplongliner/extract_l1.py
+++ b/haplongliner/extract_l1.py
@@ -1,5 +1,6 @@
 """Utility to extract full-length transposable element records from a BED file."""
 
+import re
 import sys
 from collections.abc import Iterable
 
@@ -37,13 +38,18 @@ def extract_te_from_bed(
     min_length: int = 5000,
     te: str | Iterable[str] = ("L1", "L1PA3"),
 ) -> None:
-    """Write BED records for selected TEs at least ``min_length`` bp long."""
+    """Write BED records for selected TEs at least ``min_length`` bp long.
+
+    Matches are based on prefix matching rather than exact equality so that
+    names like ``L1HS_3end`` are returned when searching for ``L1HS``.
+    """
 
     if isinstance(te, str):
         te_list = [t for t in te.split(",") if t]
     else:
         te_list = list(te)
     allowed = _expand_te_names(te_list)
+    patterns = [re.compile(fr"^{re.escape(t)}") for t in allowed]
 
     out = open(outfile, "w") if outfile else sys.stdout
     with open(infile) as f:
@@ -56,7 +62,7 @@ def extract_te_from_bed(
             name = fields[3]
             start = int(fields[1])
             end = int(fields[2])
-            if name in allowed and (end - start) >= min_length:
+            if any(p.match(name) for p in patterns) and (end - start) >= min_length:
                 print(line, end="", file=out)
     if outfile:
         out.close()

--- a/tests/test_extract_te_pattern.py
+++ b/tests/test_extract_te_pattern.py
@@ -1,0 +1,15 @@
+from haplongliner.extract_l1 import extract_te_from_bed
+
+
+def test_extract_te_pattern_matching(tmp_path):
+    bed = tmp_path / "input.bed"
+    bed.write_text(
+        "chr1\t0\t6000\tL1HS\t6000\t+\n"
+        "chr1\t0\t6000\tL1HS_3end\t6000\t+\n"
+        "chr1\t0\t6000\tL1PA3\t6000\t+\n"
+    )
+    out = tmp_path / "out.bed"
+    extract_te_from_bed(str(bed), str(out), 5000, "L1HS")
+    lines = out.read_text().strip().splitlines()
+    names = [line.split("\t")[3] for line in lines]
+    assert names == ["L1HS", "L1HS_3end"]

--- a/tests/test_sv_reference_bed.py
+++ b/tests/test_sv_reference_bed.py
@@ -1,5 +1,4 @@
 from haplongliner.sv_mode import _filter_reference_bed
-from haplongliner.sv_mode import _filter_reference_bed
 
 def test_filter_reference_hprc(tmp_path):
     raw = tmp_path / "hprc.bed"
@@ -21,3 +20,13 @@ def test_filter_reference_nonhprc(tmp_path):
     lines = out.read_text().strip().splitlines()
     assert len(lines) == 1
     assert lines[0].split("\t")[3] == "L1HS"
+
+def test_filter_reference_pattern_match(tmp_path):
+    raw = tmp_path / "ref.bed"
+    raw.write_text(
+        "chr1\t0\t6000\tL1HS_3end\t6000\t+\n" "chr1\t0\t6000\tL1PA2\t6000\t+\n",
+    )
+    out = _filter_reference_bed(raw, 5000, "L1HS", "hg38")
+    lines = out.read_text().strip().splitlines()
+    assert len(lines) == 1
+    assert lines[0].split("\t")[3] == "L1HS_3end"


### PR DESCRIPTION
## Summary
- Support prefix-based matching for TE family names (e.g. L1HS matches L1HS_3end)
- Test TE extraction and reference filtering with TE name suffixes

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75a66c2e08322a4d86cb5c26f7640