### PR TITLE
Remove temporary sv ORF files

### DIFF
--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -726,8 +726,14 @@ def _append_liftover_orfs(orf_fa: Path, sv_fa: Path) -> None:
     if not sv_fa.exists() or sv_fa.stat().st_size == 0:
         return
 
-    liftover_orf = sv_fa.with_name("sv_orf.fa")
-    run_quiet(
+    mapping: Dict[str, str] = {}
+    with open(sv_fa) as fh:
+        for line in fh:
+            if line.startswith(">"):
+                name = line[1:].strip()
+                mapping[name.replace(",", "_")] = name
+
+    result = run_quiet(
         [
             "getorf",
             "-sequence",
@@ -735,27 +741,45 @@ def _append_liftover_orfs(orf_fa: Path, sv_fa: Path) -> None:
             "-find",
             "1",
             "-outseq",
-            str(liftover_orf),
+            "stdout",
             "-minsize",
             "810",
         ],
         check=True,
+        text=True,
     )
-    _fix_getorf_headers(liftover_orf, sv_fa)
 
-    filtered = liftover_orf.with_suffix(".filtered")
-    with open(liftover_orf) as src, open(filtered, "w") as dst:
-        write = False
-        for line in src:
-            if line.startswith(">"):
-                fields = line[1:].strip().split(",")
-                write = len(fields) >= 6 and fields[5] != "INS"
-                if write:
-                    dst.write(line)
+    pattern = re.compile(r"^>([^\s]+)_([0-9]+)\s+\[([0-9]+)\s*-\s*([0-9]+)\]")
+    records: List[str] = []
+    write = False
+    for line in result.stdout.splitlines():
+        if line.startswith(">"):
+            m = pattern.match(line)
+            if m:
+                name_key, idx, start, end = m.groups()
+                orig = mapping.get(name_key, name_key)
+                header = f">{orig},{idx},{start},{end}"
             else:
-                if write:
-                    dst.write(line)
-    append_fasta(orf_fa, filtered)
+                header = line
+            fields = header[1:].strip().split(",")
+            write = len(fields) >= 6 and fields[5] != "INS"
+            if write:
+                records.append(header)
+        else:
+            if write:
+                records.append(line)
+
+    if not records:
+        return
+
+    with open(orf_fa, "ab+") as out:
+        out.seek(0, os.SEEK_END)
+        if out.tell() > 0:
+            out.seek(-1, os.SEEK_END)
+            if out.read(1) != b"\n":
+                out.write(b"\n")
+        for rec in records:
+            out.write(rec.encode() + b"\n")
 
 
 def _remove_empty_sequences(fasta_path: Path) -> None:

--- a/tests/test_sv_orf_fasta.py
+++ b/tests/test_sv_orf_fasta.py
@@ -38,20 +38,27 @@ def test_append_liftover_orfs(monkeypatch, tmp_path):
         f">chr1,50,830,780,+,INS\n{'ATG' * 270}\n"
     )
 
-    def fake_run_quiet(cmd, check=True, cwd=None, **kwargs):
+    class Dummy:
+        def __init__(self, stdout=""):
+            self.stdout = stdout
+
+    def fake_run_quiet(cmd, check=True, cwd=None, text=False, **kwargs):
         if cmd[0] == "getorf":
-            out = Path(cmd[cmd.index("-outseq") + 1])
-            if out.name == "cand_orf.fa":
-                out.write_text("")
-            else:
+            outseq = cmd[cmd.index("-outseq") + 1]
+            if outseq == "stdout":
                 prot = "M" * 270
-                out.write_text(
+                stdout = (
                     f">chr1_0_810_810_+_ALN_1 [1 - 810]\n{prot}\n"
                     f">chr1_50_830_780_+_INS_1 [1 - 780]\n{prot}\n"
                 )
+                return Dummy(stdout=stdout)
+            else:
+                Path(outseq).write_text("")
+                return Dummy()
         elif cmd[0] == "blastp":
             out = Path(cmd[cmd.index("-out") + 1])
             out.write_text("")
+            return Dummy()
 
     monkeypatch.setattr("haplongliner.sv_mode.run_quiet", fake_run_quiet)
     monkeypatch.setattr("haplongliner.sv_mode.verify_blast_db", lambda x: None)


### PR DESCRIPTION
## Summary
- Avoid writing `sv_orf.fa` and `sv_orf.filtered` by streaming getorf output and filtering in-memory
- Update ORF appending test to match new in-memory workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b75c3aceb483229240e3a4dc8f21b0