### PR TITLE
Clarify README install order for conda env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,20 @@
 
 ### Install using git and pip
 
-Create the recommended conda environment:
+Clone the repository:
+```bash
+git clone https://github.com/leiyangly/HapLongLINEr.git
+cd HapLongLINEr
+```
+
+Create and activate the recommended conda environment:
 ```bash
 conda env create -f environment.yml
 conda activate haplongliner
 ```
 
-Clone the repository:
-```bash
-git clone https://github.com/leiyangly/HapLongLINEr.git
-```
-
 Install HapLongLINEr with pip:
 ```bash
-cd HapLongLINEr
-
 pip install -e .
 ```
 


### PR DESCRIPTION
## Summary
- reorder the git+pip installation steps so users clone the repository before using environment.yml
- make the sequence explicit: clone, cd into the repo, create/activate the conda environment, then run pip install -e .

## Validation
- README wording only