### PR TITLE
Support phased haplotype-resolved SV VCFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Output:
 Input:
 - Haploid assembly FASTA
 - Structural variant (SV) callset (VCF or BED)
+- For phased haplotype-resolved SV VCFs, `--hap auto` (default) will try to infer haplotype 1 or 2 from the assembly filename; use `--hap 1`, `--hap 2`, or `--hap both` to override
 - Reference genome FASTA (hs1, hg38, or custom; default hs1)
 - Transposable element families to analyse (via `--te`, default `L1,L1PA3`)
 - Maximum insertion length for candidate extraction (via `-x/--xlength`; default 20kb or 3×`--length`, whichever is higher)
@@ -170,7 +171,9 @@ haplongliner sv \
 
 ORF validation is carried out only when `--length` is at least 5000 and the `--te` list includes L1HS, L1PA2, or L1PA3; otherwise the BLASTP and ORF sequence extraction steps are skipped.
 RepeatMasker-based candidate validation runs with `-pa 4` by default and can be
-adjusted with `-pa/--pa`.
+adjusted with `-pa/--pa`. When the SV VCF contains phased genotypes such as
+`1|0` or `0|1`, SV mode uses the selected haplotype to keep only the variants
+present on the target haploid assembly.
 
 Output:
 - haplongliner_sv.bed file summarizing TE coordinates and ORF status. Names from insertion calls that do not overlap lifted TEs end with `;nr`.

--- a/haplongliner/cli.py
+++ b/haplongliner/cli.py
@@ -280,6 +280,16 @@ def main():
         ),
     )
     parser_sv.add_argument(
+        "--hap",
+        dest="hap",
+        choices=["auto", "1", "2", "both"],
+        default="auto",
+        help=(
+            "Haplotype selection for phased SV VCFs: auto (infer from --in), "
+            "1, 2, or both (default: auto)"
+        ),
+    )
+    parser_sv.add_argument(
         "-pa",
         "--pa",
         dest="repeatmasker_pa",
@@ -494,6 +504,7 @@ def main():
             asm=args.asm,
             xlength=args.xlength,
             exist=args.exist,
+            hap=args.hap,
             repeatmasker_pa=args.repeatmasker_pa,
         )
     elif args.command == "seq":

--- a/haplongliner/sv_mode.py
+++ b/haplongliner/sv_mode.py
@@ -371,8 +371,80 @@ def _create_lifted_reorg(
 
     return lifted
 
+
+def _infer_haplotype_from_path(path: str | Path) -> Optional[str]:
+    """Infer haplotype ``"1"`` or ``"2"`` from an assembly filename."""
+
+    name = Path(path).name.lower()
+    patterns = [
+        r"(?:^|[_\.-])phased[_\.-]?([12])(?:[_\.-]|$)",
+        r"(?:^|[_\.-])hap(?:lotype)?[_\.-]?([12])(?:[_\.-]|$)",
+        r"(?:^|[_\.-])h([12])(?:[_\.-]|$)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, name)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _nonref_allele(token: str) -> bool:
+    """Return ``True`` when a genotype allele token indicates a variant allele."""
+
+    token = token.strip()
+    return bool(token) and token not in {"0", "."}
+
+
+def _vcf_record_matches_haplotype(fields: List[str], hap: str) -> bool:
+    """Return whether a VCF record should be used for the selected haplotype."""
+
+    if hap == "legacy":
+        return True
+
+    if len(fields) < 10:
+        return True
+
+    gt = fields[9].split(":", 1)[0].strip()
+    if not gt or gt in {".", "./.", ".|."}:
+        return False
+
+    if "|" in gt:
+        alleles = gt.split("|")
+        if hap == "1":
+            return bool(alleles) and _nonref_allele(alleles[0])
+        if hap == "2":
+            return len(alleles) >= 2 and _nonref_allele(alleles[1])
+        return any(_nonref_allele(a) for a in alleles)
+
+    if "/" in gt:
+        alleles = gt.split("/")
+        return any(_nonref_allele(a) for a in alleles)
+
+    return _nonref_allele(gt)
+
+
+def _resolve_sv_haplotype_selection(
+    hap: str,
+    input_fasta: str | None = None,
+) -> Tuple[str, str]:
+    """Resolve the effective haplotype-selection mode for VCF parsing."""
+
+    if hap in {"1", "2", "both"}:
+        return hap, f"explicit {hap}"
+
+    if input_fasta:
+        inferred = _infer_haplotype_from_path(input_fasta)
+        if inferred:
+            return inferred, f"auto from input filename ({Path(input_fasta).name})"
+
+    return "both", "auto fallback to both"
+
+
 def _parse_sv(
-    sv_path: Path, log_path: Path | None = None
+    sv_path: Path,
+    log_path: Path | None = None,
+    *,
+    hap: str = "legacy",
 ) -> Tuple[List[Tuple[str, int, int]], List[Tuple[str, int, int, str]]]:
     """Parse a simple VCF or BED SV file and return deletion and insertion regions.
 
@@ -392,6 +464,8 @@ def _parse_sv(
             fields = line.rstrip().split("\t")
             if is_vcf or len(fields) > 5:
                 try:
+                    if not _vcf_record_matches_haplotype(fields, hap):
+                        continue
                     chrom = fields[0]
                     pos = int(fields[1]) - 1
                     info = fields[7] if len(fields) > 7 else ""
@@ -1068,6 +1142,7 @@ def run_sv_mode(
     xlength: int | None = None,
     exist: str = "no",
     repeatmasker_pa: int = 4,
+    hap: str = "auto",
 ) -> None:
     """RepeatMasker-free TE discovery using structural variants.
 
@@ -1085,6 +1160,7 @@ def run_sv_mode(
     perform_orf = min_length >= 5000 and bool(expanded_te & {"L1HS", "L1PA2", "L1PA3"})
     if xlength is None:
         xlength = max(20000, 3 * min_length)
+    resolved_hap, hap_note = _resolve_sv_haplotype_selection(hap, input_fasta)
 
     info_lines = [
         "[INFO] SV mode running with:",
@@ -1096,6 +1172,7 @@ def run_sv_mode(
         f"[INFO]   ASM preset: asm{asm}",
         f"[INFO]   Max insertion length: {xlength}",
         f"[INFO]   RepeatMasker -pa: {repeatmasker_pa}",
+        f"[INFO]   SV haplotype selection: {resolved_hap} ({hap_note})",
     ]
     print("\n".join(info_lines))
 
@@ -1216,7 +1293,11 @@ def run_sv_mode(
 
     print("\n[STEP 4] Parsing structural variants")
 
-    deletions, insertions = _parse_sv(Path(sv_file), Path(log) if log else None)
+    deletions, insertions = _parse_sv(
+        Path(sv_file),
+        Path(log) if log else None,
+        hap=resolved_hap,
+    )
     print(f"[SUM] Parsed {len(deletions)} deletions and {len(insertions)} insertions")
 
     print("\n[STEP 5] Validating candidate TEs")

--- a/tests/test_cli_repeatmasker_pa.py
+++ b/tests/test_cli_repeatmasker_pa.py
@@ -81,3 +81,34 @@ def test_cli_sv_repeatmasker_pa_override(monkeypatch):
     cli.main()
 
     assert captured["kwargs"]["repeatmasker_pa"] == 12
+
+
+def test_cli_sv_haplotype_option(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(cli, "check_dependencies", lambda: None)
+
+    def fake_run_sv_mode(*args, **kwargs):
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(cli, "run_sv_mode", fake_run_sv_mode)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "haplongliner",
+            "sv",
+            "-i",
+            "HG00410.LSK110.R9_hapdup_phased_2.fasta",
+            "-s",
+            "calls.vcf",
+            "-o",
+            "outdir",
+            "--hap",
+            "2",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["kwargs"]["hap"] == "2"

--- a/tests/test_sv.py
+++ b/tests/test_sv.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from haplongliner.sv_mode import _parse_sv, run_sv_mode
+from haplongliner.sv_mode import (
+    _parse_sv,
+    _resolve_sv_haplotype_selection,
+    run_sv_mode,
+)
 
 
 def test_parse_sv_handles_gz(tmp_path):
@@ -53,3 +57,43 @@ def test_reuse_existing_alignment(monkeypatch, tmp_path):
 
     assert not called["flag"]
 
+
+def test_parse_sv_filters_phased_haplotype_vcf(tmp_path):
+    vcf = tmp_path / "calls.vcf"
+    vcf.write_text(
+        "##fileformat=VCFv4.2\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSample\n"
+        "chr1\t11\tdel1\tA\t<DEL>\t.\tPASS\tSVTYPE=DEL;END=21\tGT\t1|0\n"
+        "chr1\t31\tdel2\tA\t<DEL>\t.\tPASS\tSVTYPE=DEL;END=41\tGT\t0|1\n"
+        "chr1\t51\tdel3\tA\t<DEL>\t.\tPASS\tSVTYPE=DEL;END=61\tGT\t1|1\n"
+        "chr1\t71\tdel4\tA\t<DEL>\t.\tPASS\tSVTYPE=DEL;END=81\tGT\t0|0\n"
+        "chr1\t91\tins1\tA\tACGT\t.\tPASS\tSVTYPE=INS;END=91\tGT\t0/1\n"
+    )
+
+    del1, ins1 = _parse_sv(vcf, hap="1")
+    del2, ins2 = _parse_sv(vcf, hap="2")
+    delb, insb = _parse_sv(vcf, hap="both")
+
+    assert del1 == [("chr1", 10, 20), ("chr1", 50, 60)]
+    assert del2 == [("chr1", 30, 40), ("chr1", 50, 60)]
+    assert delb == [("chr1", 10, 20), ("chr1", 30, 40), ("chr1", 50, 60)]
+    assert ins1 == [("chr1", 90, 91, "ACGT")]
+    assert ins2 == [("chr1", 90, 91, "ACGT")]
+    assert insb == [("chr1", 90, 91, "ACGT")]
+
+
+def test_resolve_sv_haplotype_selection_auto_from_input_name():
+    resolved, note = _resolve_sv_haplotype_selection(
+        "auto",
+        "/tmp/HG00410.LSK110.R9_hapdup_phased_1.fasta",
+    )
+
+    assert resolved == "1"
+    assert "phased_1" in note
+
+
+def test_resolve_sv_haplotype_selection_auto_falls_back_to_both():
+    resolved, note = _resolve_sv_haplotype_selection("auto", "/tmp/sample.fa")
+
+    assert resolved == "both"
+    assert "fallback" in note


### PR DESCRIPTION
## Summary
- add haplotype-aware VCF parsing to SV mode with a new --hap option
- auto-infer haplotype 1 or 2 from input assembly names like phased_1/phased_2, while keeping legacy inclusive parsing for direct parser calls
- document phased SV VCF handling and add focused parser/CLI tests

## Validation
- python -m py_compile haplongliner/cli.py haplongliner/sv_mode.py
- python -m pytest -q tests/test_sv.py tests/test_cli_repeatmasker_pa.py tests/test_sv_classify.py tests/test_sv_reference_bed.py tests/test_validate_presence.py
- python -m haplongliner.cli sv -h